### PR TITLE
pixscale and decals-dir are now optional inputs

### DIFF
--- a/projects/desi/check-astrom.py
+++ b/projects/desi/check-astrom.py
@@ -30,8 +30,8 @@ if __name__ == '__main__':
     #img = fitsio.read(fn, ext=ccd.cpimage_hdu)
     #print 'img', img.shape
 
-    im = DecamImage(ccd)
-    tim = im.get_tractor_image(D)
+    im = DecamImage(D, ccd)
+    tim = im.get_tractor_image()
     print 'Tim', tim.shape
 
     calname = ccd.calname.strip()

--- a/projects/desi/check-psf.py
+++ b/projects/desi/check-psf.py
@@ -42,7 +42,7 @@ if __name__ == '__main__':
     band = T.filter[0]
     print 'Band:', band
 
-    im = DecamImage(T[0])
+    im = DecamImage(decals, T[0])
     print 'Reading', im.imgfn
 
     # Get approximate image center for astrometry

--- a/projects/desi/common.py
+++ b/projects/desi/common.py
@@ -1544,7 +1544,7 @@ class DecamImage(object):
         if os.path.exists(imgfn):
             self.imgfn = imgfn
         else:
-            self.imgfn = os.path.join(decals.decals_dir, 'images', imgfn)
+            self.imgfn = os.path.join(self.decals_dir, 'images', imgfn)
         self.hdu   = hdu
         self.expnum = expnum
         self.extname = extname

--- a/projects/desi/common.py
+++ b/projects/desi/common.py
@@ -1156,7 +1156,7 @@ def run_sed_matched_filters(SEDs, bands, detmaps, detivs, omit_xy,
     return Tnew, newcat, hot
 
 class Decals(object):
-    def __init__(self,decals_dir=None):
+    def __init__(self, decals_dir=None):
         if decals_dir is None:
             decals_dir = os.environ.get('DECALS_DIR')
             if decals_dir is None:
@@ -1164,12 +1164,12 @@ class Decals(object):
                 print 'On NERSC, you can do:'
                 print '  module use /project/projectdirs/cosmo/work/decam/versions/modules'
                 print '  module load decals'
+                print 'Using the current directory as DECALS_DIR, but this is likely to fail.'
                 print
-        
+                decals_dir = os.getcwd()
+                
         self.decals_dir = decals_dir
-        self.calibdir = os.path.join(self.decals_dir, 'calib', 'decam')
-        self.sedir = os.path.join(self.decals_dir, 'calib', 'se-config')
-        self.an_config = os.path.join(self.decals_dir, 'calib', 'an-config', 'cfg')
+
         self.ZP = None
         self.bricks = None
 
@@ -1178,7 +1178,19 @@ class Decals(object):
         self.bricktree = None
         ### HACK! Hard-coded brick edge size, in degrees!
         self.bricksize = 0.25
-        
+
+    def get_calib_dir(self):
+        return os.path.join(self.decals_dir, 'calib', 'decam')
+
+    def get_image_dir(self):
+        return os.path.join(self.decals_dir, 'images')
+
+    def get_decals_dir(self):
+        return self.decals_dir
+
+    def get_se_dir(self):
+        return os.path.join(self.decals_dir, 'calib', 'se-config')
+
     def get_bricks(self):
         return fits_table(os.path.join(self.decals_dir, 'decals-bricks.fits'))
 
@@ -1280,13 +1292,13 @@ class Decals(object):
         for t in C:
             print
             print 'Image file', t.cpimage, 'hdu', t.cpimage_hdu
-            im = DecamImage(t)
+            im = DecamImage(self, t)
             ims.append(im)
         # Read images, clip to ROI
         W,H = targetwcs.get_width(), targetwcs.get_height()
         targetrd = np.array([targetwcs.pixelxy2radec(x,y) for x,y in
                              [(1,1),(W,1),(W,H),(1,H),(1,1)]])
-        args = [(im, self, targetrd, mock_psf, const2psf) for im in ims]
+        args = [(im, targetrd, mock_psf, const2psf) for im in ims]
         tims = mp.map(read_one_tim, args)
         return tims
     
@@ -1530,12 +1542,8 @@ def exposure_metadata(filenames, hdus=None, trim=None):
     return T
 
 class DecamImage(object):
-    def __init__(self, t):
-        decals = Decals()
-        self.decals_dir = decals.decals_dir
-        self.calibdir = decals.calibdir
-        self.sedir = decals.sedir
-        self.an_config = decals.an_config
+    def __init__(self, decals, t):
+        self.decals = decals
 
         imgfn, hdu, band, expnum, extname, calname, exptime = (
             t.cpimage.strip(), t.cpimage_hdu, t.filter.strip(), t.expnum,
@@ -1544,20 +1552,15 @@ class DecamImage(object):
         if os.path.exists(imgfn):
             self.imgfn = imgfn
         else:
-            self.imgfn = os.path.join(self.decals_dir, 'images', imgfn)
+            self.imgfn = os.path.join(self.decals.get_image_dir(), imgfn)
+        self.dqfn = self.imgfn.replace('_ooi_', '_ood_')
+        self.wtfn = self.imgfn.replace('_ooi_', '_oow_')
+
         self.hdu   = hdu
         self.expnum = expnum
         self.extname = extname
         self.band  = band
         self.exptime = exptime
-
-        # EDR filenames: .imag.fits, .ivar.fits, .mask.fits.gz
-        if '.imag.fits' in self.imgfn:
-            self.dqfn = self.imgfn.replace('.imag.fits', '.mask.fits.gz')
-            self.wtfn = self.imgfn.replace('.imag.fits', '.ivar.fits')
-        else:
-            self.dqfn = self.imgfn.replace('_ooi_', '_ood_')
-            self.wtfn = self.imgfn.replace('_ooi_', '_oow_')
 
         for attr in ['imgfn', 'dqfn', 'wtfn']:
             fn = getattr(self, attr)
@@ -1582,18 +1585,19 @@ class DecamImage(object):
 
         self.calname = calname
         self.name = '%08i-%s' % (expnum, extname)
-        
-        self.pvwcsfn = os.path.join(self.calibdir, 'astrom-pv', calname + '.wcs.fits')
-        self.sefn = os.path.join(self.calibdir, 'sextractor', calname + '.fits')
-        self.psffn = os.path.join(self.calibdir, 'psfex', calname + '.fits')
-        self.skyfn = os.path.join(self.calibdir, 'sky', calname + '.fits')
+
+        calibdir = self.decals.get_calib_dir()
+        self.pvwcsfn = os.path.join(calibdir, 'astrom-pv', calname + '.wcs.fits')
+        self.sefn = os.path.join(calibdir, 'sextractor', calname + '.fits')
+        self.psffn = os.path.join(calibdir, 'psfex', calname + '.fits')
+        self.skyfn = os.path.join(calibdir, 'sky', calname + '.fits')
 
     def __str__(self):
         return self.name
     def __repr__(self):
         return str(self)
 
-    def get_tractor_image(self, decals, slc=None, radecpoly=None,
+    def get_tractor_image(self, slc=None, radecpoly=None,
                           mock_psf=False, const2psf=False,
                           nanomaggies=True, subsky=True, tiny=5):
         '''
@@ -1602,7 +1606,7 @@ class DecamImage(object):
         band = self.band
         imh,imw = self.get_image_shape()
 
-        wcs = self.read_pv_wcs(decals)
+        wcs = self.read_pv_wcs()
         x0,y0 = 0,0
         if slc is None and radecpoly is not None:
             imgpoly = [(1,1),(1,imh),(imw,imh),(imw,1)]
@@ -1673,7 +1677,7 @@ class DecamImage(object):
         psf_sigma = psf_fwhm / 2.35
         primhdr = self.read_image_primary_header()
 
-        magzp = decals.get_zeropoint_for(self)
+        magzp = self.decals.get_zeropoint_for(self)
         print 'magzp', magzp
         orig_zpscale = zpscale = NanoMaggies.zeropointToScale(magzp)
 
@@ -1836,10 +1840,10 @@ class DecamImage(object):
             invvar[invvar < thresh] = 0
         return invvar
 
-    def read_pv_wcs(self, decals):
+    def read_pv_wcs(self):
         print 'Reading WCS from', self.pvwcsfn
         wcs = Sip(self.pvwcsfn)
-        dra,ddec = decals.get_astrometric_zeropoint_for(self)
+        dra,ddec = self.decals.get_astrometric_zeropoint_for(self)
         r,d = wcs.get_crval()
         print 'Applying astrometric zeropoint:', (dra,ddec)
         wcs.set_crval((r + dra, d + ddec))
@@ -1995,13 +1999,14 @@ class DecamImage(object):
             maskstr = ''
             if use_mask:
                 maskstr = '-FLAG_IMAGE ' + funmaskfn
+            sedir = self.decals.get_se_dir()
             cmd = ' '.join([
                 'sex',
-                '-c', os.path.join(self.sedir, 'DECaLS-v2.sex'),
+                '-c', os.path.join(sedir, 'DECaLS-v2.sex'),
                 maskstr, '-SEEING_FWHM %f' % seeing,
-                '-PARAMETERS_NAME', os.path.join(self.sedir, 'DECaLS-v2.param'),
-                '-FILTER_NAME', os.path.join(self.sedir, 'gauss_5.0_9x9.conv'),
-                '-STARNNW_NAME', os.path.join(self.sedir, 'default.nnw'),
+                '-PARAMETERS_NAME', os.path.join(sedir, 'DECaLS-v2.param'),
+                '-FILTER_NAME', os.path.join(sedir, 'gauss_5.0_9x9.conv'),
+                '-STARNNW_NAME', os.path.join(sedir, 'default.nnw'),
                 '-PIXEL_SCALE 0',
                 # SE has a *bizarre* notion of "sigma"
                 '-DETECT_THRESH 1.0',
@@ -2023,7 +2028,7 @@ class DecamImage(object):
             if os.system(cmd):
                 raise RuntimeError('Command failed: ' + cmd)
             # Read the resulting WCS header and add version info cards to it.
-            version_hdr = get_version_header(None, self.decals_dir)
+            version_hdr = get_version_header(None, self.decals.get_decals_dir())
             wcshdr = fitsio.read_header(tmpwcsfn)
             os.unlink(tmpwcsfn)
             for r in wcshdr.records():
@@ -2032,6 +2037,7 @@ class DecamImage(object):
             print 'Wrote', self.pvwcsfn
 
         if psfex:
+            sedir = self.decals.get_se_dir()
             # If we wrote *.psf instead of *.fits in a previous run...
             oldfn = self.psffn.replace('.fits', '.psf')
             if os.path.exists(oldfn):
@@ -2039,7 +2045,7 @@ class DecamImage(object):
                 os.rename(oldfn, self.psffn)
             else:
                 cmd = ('psfex -c %s -PSF_DIR %s %s' %
-                       (os.path.join(self.sedir, 'DECaLS-v2.psfex'),
+                       (os.path.join(sedir, 'DECaLS-v2.psfex'),
                         os.path.dirname(self.psffn), self.sefn))
                 print cmd
                 rtn = os.system(cmd)
@@ -2060,7 +2066,7 @@ class DecamImage(object):
             tsky = ConstantSky(skyval)
             tt = type(tsky)
             sky_type = '%s.%s' % (tt.__module__, tt.__name__)
-            hdr = get_version_header(None, self.decals_dir)
+            hdr = get_version_header(None, self.decals.get_decals_dir())
             hdr.add_record(dict(name='SKYMETH', value=skymeth,
                                 comment='estimate_mode, or fallback to median?'))
             hdr.add_record(dict(name='SKY', value=sky_type, comment='Sky class'))
@@ -2082,9 +2088,9 @@ def run_calibs(X):
     return im.run_calibs(*args, **kwargs)
 
 
-def read_one_tim((im, decals, targetrd, mock_psf, const2psf)):
+def read_one_tim((im, targetrd, mock_psf, const2psf)):
     print 'Reading expnum', im.expnum, 'name', im.extname, 'band', im.band, 'exptime', im.exptime
-    tim = im.get_tractor_image(decals, radecpoly=targetrd, mock_psf=mock_psf,
+    tim = im.get_tractor_image(radecpoly=targetrd, mock_psf=mock_psf,
                                const2psf=const2psf)
     return tim
 

--- a/projects/desi/create_model_image.py
+++ b/projects/desi/create_model_image.py
@@ -36,7 +36,7 @@ def main():
     print 'Closest chip:', chips[D[0]]
     chips = [chips[D[0]]]
 
-    im = DecamImage(chips[0])
+    im = DecamImage(decals, chips[0])
     print 'Image:', im
 
     targetwcs = Sip(im.wcsfn)
@@ -80,7 +80,7 @@ def main():
     slc = None
     if roi is not None:
         slc = slice(y0,y1), slice(x0,x1)
-    tim = im.get_tractor_image(decals, slc=slc)
+    tim = im.get_tractor_image(slc=slc)
     print 'Got', tim
     tim.psfex.fitSavedData(*tim.psfex.splinedata)
     tim.psfex.radius = 20

--- a/projects/desi/forced-photom-decam.py
+++ b/projects/desi/forced-photom-decam.py
@@ -56,9 +56,9 @@ if __name__ == '__main__':
     print 'Metadata:'
     T.about()
 
-    im = DecamImage(T[0])
     decals = Decals()
-    tim = im.get_tractor_image(decals, slc=zoomslice, const2psf=True)
+    im = DecamImage(decals, T[0])
+    tim = im.get_tractor_image(slc=zoomslice, const2psf=True)
     print 'Got tim:', tim
 
     if catfn == 'DR1':

--- a/projects/desi/lsb.py
+++ b/projects/desi/lsb.py
@@ -62,14 +62,14 @@ def stage_1(expnum=431202, extname='S19', plotprefix='lsb', plots=False,
     decals = Decals()
     C = decals.find_ccds(expnum=expnum, extname=extname)
     print len(C), 'CCDs'
-    im = DecamImage(C[0])
+    im = DecamImage(decals, C[0])
     print 'im', im
     
     #(x0,x1,y0,y1) = opt.zoom
     #zoomslice = (slice(y0,y1), slice(x0,x1))
     zoomslice = None
     
-    tim = im.get_tractor_image(decals, const2psf=True, slc=zoomslice)
+    tim = im.get_tractor_image(const2psf=True, slc=zoomslice)
     print 'Tim', tim
     
     cats = []

--- a/projects/desi/queue-calibs.py
+++ b/projects/desi/queue-calibs.py
@@ -374,7 +374,7 @@ if __name__ == '__main__':
 
         if opt.delete_sky or opt.delete_pvastrom:
             print j+1, 'of', len(allI)
-            im = DecamImage(T[i])
+            im = DecamImage(decals, T[i])
             if opt.delete_sky and os.path.exists(im.skyfn):
                 print '  deleting:', im.skyfn
                 os.unlink(im.skyfn)
@@ -384,7 +384,7 @@ if __name__ == '__main__':
 
         if opt.check:
             print j+1, 'of', len(allI)
-            im = DecamImage(T[i])
+            im = DecamImage(decals, T[i])
             if not im.run_calibs(im, None, None, None, just_check=True,
                                  astrom=False):
                 print 'Calibs for', im.expnum, im.extname, im.calname, 'already done'
@@ -518,7 +518,7 @@ if __name__ == '__main__':
     f = open('jobs','w')
     log('Total of', len(allI), 'CCDs')
     for i in allI:
-        im = DecamImage(T[i])
+        im = DecamImage(decals, T[i])
         if not im.run_calibs(im, None, None, None, just_check=True,
                              psfex=False, psfexfit=False):
             continue
@@ -542,7 +542,7 @@ if __name__ == '__main__':
         im = None
         try:
             for t in T[I]:
-                im = DecamImage(t)
+                im = DecamImage(decals, t)
                 zp = decals.get_zeropoint_for(im)
         except:
             print >> sys.stderr, 'Brick', b.brickid, ': Failed to get zeropoint for', im

--- a/projects/desi/render-model-decam.py
+++ b/projects/desi/render-model-decam.py
@@ -45,9 +45,9 @@ if __name__ == '__main__':
     print 'Metadata:'
     T.about()
 
-    im = DecamImage(T[0])
     decals = Decals()
-    tim = im.get_tractor_image(decals, slc=zoomslice, nanomaggies=opt.nmgy,
+    im = DecamImage(decals, T[0])
+    tim = im.get_tractor_image(slc=zoomslice, nanomaggies=opt.nmgy,
                                subsky=opt.no_sky, const2psf=True)
     print 'Got tim:', tim
 

--- a/projects/desi/reoptimize.py
+++ b/projects/desi/reoptimize.py
@@ -77,8 +77,8 @@ if __name__ == '__main__':
     decals = Decals()
     tims = []
     for t in T:
-        im = DecamImage(t)
-        tim = im.get_tractor_image(decals) #, slc=zoomslice)
+        im = DecamImage(decals, t)
+        tim = im.get_tractor_image() #, slc=zoomslice)
         print 'Got tim:', tim
         from tractor.psfex import CachingPsfEx
         tim.psfex.radius = 20

--- a/projects/desi/run-calib.py
+++ b/projects/desi/run-calib.py
@@ -4,7 +4,7 @@ import os
 import numpy as np
 from astrometry.util.fits import fits_table
 
-from common import decals_dir, run_calibs, DecamImage, Decals
+from common import run_calibs, DecamImage, Decals
 
 if __name__ == '__main__':
     import optparse
@@ -42,7 +42,7 @@ if __name__ == '__main__':
         t = T[i]
         print 'Running', t.calname
 
-        im = DecamImage(t)
+        im = DecamImage(D, t)
 
         pixscale = np.sqrt(np.abs(t.cd1_1 * t.cd2_2 - t.cd1_2 * t.cd2_1))
         pixscale *= 3600.

--- a/projects/desi/runbrick.py
+++ b/projects/desi/runbrick.py
@@ -3243,7 +3243,8 @@ python -u projects/desi/runbrick.py --plots --brick 2440p070 --zoom 1900 2400 45
         kwa.update(nsigma=opt.nsigma)
     if opt.no_sdss:
         kwa.update(sdssInit=False)
-        
+    if opt.no_wise:
+        kwa.update(wise=False)
         
     run_brick(opt.brick, radec=opt.radec, pixscale=opt.pixscale,
               width=opt.width, height=opt.height, zoom=opt.zoom,

--- a/projects/desi/runbrick.py
+++ b/projects/desi/runbrick.py
@@ -368,7 +368,7 @@ def stage_tims(W=3600, H=3600, pixscale=0.262, brickname=None, ra=None, dec=None
     for t in T:
         print
         print 'Image file', t.cpimage, 'hdu', t.cpimage_hdu
-        im = DecamImage(t)
+        im = DecamImage(decals, t)
         ims.append(im)
 
     tnow = Time()
@@ -385,7 +385,7 @@ def stage_tims(W=3600, H=3600, pixscale=0.262, brickname=None, ra=None, dec=None
     tlast = tnow
 
     # Read images, clip to ROI
-    args = [(im, decals, targetrd, mock_psf, const2psf) for im in ims]
+    args = [(im, targetrd, mock_psf, const2psf) for im in ims]
     tims = _map(read_one_tim, args)
 
     # Cut the table of CCDs to match the 'tims' list

--- a/projects/desi/runbrick.py
+++ b/projects/desi/runbrick.py
@@ -3248,10 +3248,12 @@ python -u projects/desi/runbrick.py --plots --brick 2440p070 --zoom 1900 2400 45
         
     run_brick(opt.brick, radec=opt.radec, pixscale=opt.pixscale,
               width=opt.width, height=opt.height, zoom=opt.zoom,
+              pv=opt.pv,
               threads=opt.threads, ceres=opt.ceres,
               gaussPsf=opt.gpsf, simulOpt=opt.simul_opt,
               nblobs=opt.nblobs, blob=opt.blob, blobxy=opt.blobxy,
               pipe=opt.pipe, outdir=opt.outdir, decals_dir=opt.decals_dir,
+              plots=opt.plots, plots2=opt.plots2,
               plotbase=opt.plot_base, plotnumber=opt.plot_number,
               force=opt.force, forceAll=opt.forceall,
               stages=opt.stage, writePickles=opt.write,

--- a/projects/desi/runbrick_extra.py
+++ b/projects/desi/runbrick_extra.py
@@ -103,7 +103,7 @@ def check_touching(decals, targetwcs, bands, brick, pixscale, ps):
         plt.plot(TT2.ra, TT2.dec, 'o', color=ccmap[band], alpha=0.5)
 
         for t in TT2:
-            im = DecamImage(t)
+            im = DecamImage(decals, t)
 
             run_calibs(im, brick.ra, brick.dec, pixscale, morph=False, se2=False,
                        psfex=False)
@@ -117,7 +117,7 @@ def check_touching(decals, targetwcs, bands, brick, pixscale, ps):
         plt.plot(TT2.ra, TT2.dec, 'x', color=ccmap[band], alpha=0.5, ms=15)
 
         for t in TT2:
-            im = DecamImage(t)
+            im = DecamImage(decals, t)
             wcs = im.read_wcs()
             r,d = wcs.pixelxy2radec([1,1,t.width,t.width,1], [1,t.height,t.height,1,1])
             plt.plot(r, d, '-', color=ccmap[band], lw=1.5)

--- a/projects/desi/se-cats.py
+++ b/projects/desi/se-cats.py
@@ -33,7 +33,7 @@ if __name__ == '__main__':
     for t in T:
         #if t.filter != 'r':
         #    continue
-        im = DecamImage(t)
+        im = DecamImage(D, t)
 
         run_calibs(im, t.ra, t.dec, 0.262, morph=False)
 

--- a/projects/desi/zeropoints.py
+++ b/projects/desi/zeropoints.py
@@ -51,7 +51,7 @@ if __name__ == '__main__':
         for t in TT:
             print
             print 'Image file', t.cpimage, 'hdu', t.cpimage_hdu
-            im = DecamImage(t)
+            im = DecamImage(D, t)
             ims.append(im)
 
         chipnames = []


### PR DESCRIPTION
The title speaks for itself.  I tested the code a few different ways and wasn't able to break it, so hopefully this is mostly right.  decals_dir and the affiliated calibration directories are no longer global variables in common.py, but by initializing the Decals() class in DecamImage() class and passing forward decals_dir and the calibration directories everything seems to work OK.

The one thing I wasn't sure about in runbrick.py was the difference between initargs.update() and kwargs.update(), but I ended up using the former.

I'm also not sure how the code will die in Decals() if $DECALS_DIR *and* the optional input decals_dir are both not passed.  Right now there's a printed error message and not much more.
