### PR TITLE
Optimised Herschel

### DIFF
--- a/projects/herschel/herschel-dust.py
+++ b/projects/herschel/herschel-dust.py
@@ -137,6 +137,12 @@ class DustPhotoCal(ParamList):
                                        brightness.logtemperature,
                                        brightness.emissivity)
 
+class MeltedNpArrayParams(NpArrayParams):
+    '''
+    An implementation of NpArrayParams with always liquid parameters
+    '''
+    def getParam(self,i):
+        return self._getThing(i)
 
 class DustSheet(MultiParams):
     '''
@@ -152,9 +158,9 @@ class DustSheet(MultiParams):
         assert(logsolidangle.shape == logtemperature.shape)
         assert(logsolidangle.shape == emissivity.shape)
         assert(logsolidangle.shape == (wcs.get_height(), wcs.get_width()))
-        super(DustSheet, self).__init__(NpArrayParams(logsolidangle),
-                                        NpArrayParams(logtemperature),
-                                        NpArrayParams(emissivity))
+        super(DustSheet, self).__init__(MeltedNpArrayParams(logsolidangle),
+                                        MeltedNpArrayParams(logtemperature),
+                                        MeltedNpArrayParams(emissivity))
         self.wcs = wcs
 
         self.Tcache = {}

--- a/projects/herschel/herschel-dust.py
+++ b/projects/herschel/herschel-dust.py
@@ -470,9 +470,6 @@ class DustSheet(MultiParams):
                 else:
                     outimg = rim.ravel()
 
-                if sum(outimg) == 0:
-                    continue
-
                 I = np.flatnonzero((outimg > 0) *
                                    (img.getInvError().ravel() > 0))
 


### PR DESCRIPTION
Small tweaks to `herschel-dust.py` to improve performance.

### Performance
Overall time for benchmark was measured with cProfile.

* oryginal code: 1631.864 seconds
* using `MeltedNpArrayParams`:  832.339 seconds
* using `MeltedNpArrayParams` and improved `_computeTransformation`: 339.882 seconds.
