### PR TITLE
Changes to _get_iv to compute covariant errors

### DIFF
--- a/tractor/optimize.py
+++ b/tractor/optimize.py
@@ -413,14 +413,29 @@ class Optimizer(object):
                 # trim the slice.
                 # (slice indexing correctly handles when the umod extends off
                 # the positive end)
+
+                # also need to slice the unit flux model properly if they extend off the image, 
+                # From Dan Masters
                 if x0 < 0:
                     uw += x0
                     x0 = 0
+                    um_start_x = -x0
+                else: 
+                    um_start_x = 0
+
                 if y0 < 0:
                     uh += y0
                     y0 = 0
+                    um_start_y = -y0
+                else: 
+                    um_start_y = 0
+
+                x1 = np.min([x0+uw, tim.shape[1]])
+                y1 = np.min([y0+uh, tim.shape[0]])
+
                 slc = slice(y0, y0 + uh), slice(x0, x0 + uw)
-                models_cov[ui][slc] += um.getImage() # add psfs
+                slc_model = slice(um_start_y, um_start_y+(y1-y0)), slice(um_start_x, um_start_x+(x1-x0))
+                models_cov[ui][slc] += um.getImage()[slc_model] # add psfs
 
         # faster implementation of the fisher information matrix
         F = np.zeros(shape=(D,D))
@@ -428,12 +443,14 @@ class Optimizer(object):
         if np.any(np.isnan(F)) or np.any(np.isinf(F)):
             raise ValueError("Fisher matrix contains NaNs or Infs.")
 
-        # check if F is invertible or not
-        if np.linalg.det(F)==0.:
-            print('F is not invertible! Infinity in the covariance.')
-            C = np.inf + np.zeros_like(F)
-        else:
+        # Calculate covariance matrix by inverting Fisher information matrix
+        try:
             C = np.linalg.inv(F)
+
+        except np.linalg.LinAlgError as e:
+            # Handle the case where F is not invertible
+            print(f'Error: {e}. F is not invertible!')
+            C = np.inf + np.zeros_like(F)
         
         var = -np.diag(C)
         IV[Nsky:] = 1/var # inverse variance. 

--- a/tractor/optimize.py
+++ b/tractor/optimize.py
@@ -396,9 +396,11 @@ class Optimizer(object):
                 IV[di] = dchi2
 
         # source params next
+        D = len(umodels[0]) # number of sources
         for i, (tim, umods, scale) in enumerate(zip(imlist, umodels, scales)):
             mm = np.zeros(tim.shape)
             ie = tim.getInvError()
+            models_cov = np.zeros(shape=(D, tim.shape[0], tim.shape[1])) # a tim.shape image for each source containing only PSF
             for ui, um in enumerate(umods):
                 if um is None:
                     continue
@@ -417,9 +419,25 @@ class Optimizer(object):
                     uh += y0
                     y0 = 0
                 slc = slice(y0, y0 + uh), slice(x0, x0 + uw)
-                dchi2 = np.sum((mm[slc] * scale * ie[slc]) ** 2)
-                IV[Nsky + ui] += dchi2
-                mm[slc] = 0.
+                models_cov[ui][slc] += um.getImage() # add only PSF
+                # dchi2 = np.sum((mm[slc] * scale * ie[slc]) ** 2)
+                # IV[Nsky + ui] += dchi2
+                # mm[slc] = 0.
+                
+        F = np.zeros(shape=(D,D)) # initialize fisher information matrix
+        for i in range(D):
+            for j in range(D):
+                F[i, j] = F[i,j] = -np.sum( models_cov[i]*models_cov[j] * ie**2)
+
+        # Check if F is invertible or not; then invert it if so.
+        if np.linalg.det(F)==0.:
+            print('F is not invertible! Infinity in the covariance.')
+            C = np.inf + np.zeros_like(F) # covariance matrix 
+        else:
+            C = np.linalg.inv(F) # covariance matrix
+        var = -np.diag(C) # diagonal values as variance
+        IV[Nsky:] = 1/var # inverse variance. 
+
         return IV
 
     def tryUpdates(self, tractor, X, alphas=None):

--- a/tractor/optimize.py
+++ b/tractor/optimize.py
@@ -415,18 +415,17 @@ class Optimizer(object):
                 # the positive end)
 
                 # also need to slice the unit flux model properly if they extend off the image, 
-                # From Dan Masters
                 if x0 < 0:
                     uw += x0
-                    x0 = 0
                     um_start_x = -x0
+                    x0 = 0
                 else: 
                     um_start_x = 0
 
                 if y0 < 0:
                     uh += y0
-                    y0 = 0
                     um_start_y = -y0
+                    y0 = 0
                 else: 
                     um_start_y = 0
 


### PR DESCRIPTION
Added changes to the function _get_iv in optimize.py 
- placed each unit flux model in a corresponding image 
- calculated Fisher information matrix F
- found the covariance matrix C by inverting F
- read off the variance from the diagonal values in C.

The algorithm passed the z-score test where as I fixed the primary source at the center and marched a secondary source along the central x-axis (approaching, overlapping, and then leaving the primary source), I repeated the tractor fit 500 times and plotted a histogram of z-score for each position. The z-score histogram follows a Gaussian of sigma~1 distribution except when the two sources completely overlap. So this is fairly stable. For a three-source test, it's also reasonable. 