### PR TITLE
psfex can use windowed centroids

### DIFF
--- a/tractor/psfex.py
+++ b/tractor/psfex.py
@@ -181,8 +181,8 @@ class PsfExModel(object):
             else:
                 assert(hdr['POLNGRP'] == 1)
                 # PSF distortion bases are polynomials of x,y
-                assert(hdr['POLNAME1'].strip() == 'X_IMAGE')
-                assert(hdr['POLNAME2'].strip() == 'Y_IMAGE')
+                assert(hdr['POLNAME1'].strip() in ['X_IMAGE','XWIN_IMAGE'])
+                assert(hdr['POLNAME2'].strip() in ['Y_IMAGE','YWIN_IMAGE'])
                 assert(hdr['POLGRP1'] == 1)
                 assert(hdr['POLGRP2'] == 1)
                 x0 = hdr.get('POLZERO1')


### PR DESCRIPTION
edited PsfExModel to allow the use of psf files created from a catalogue with X[Y]WIN_IMAGE and not only X[Y]_IMAGE