### PR TITLE
Craig clean

### DIFF
--- a/tractor/batch_psf.py
+++ b/tractor/batch_psf.py
@@ -16,12 +16,74 @@ from tractor.utils import BaseParams, ParamList, MultiParams, MogParams
 from tractor import mixture_profiles as mp
 from tractor import ducks
 import cupy as cp
+import time
+tbs = np.zeros(9)
 
 if sys.version_info[0] == 2:
     # Py2
     def round(x):
         import __builtin__
         return int(__builtin__.round(float(x)))
+
+def lanczos_shift_image(img, dx, dy, inplace=False, force_python=False):
+    H,W = img.shape
+    # fallback to python:
+    from scipy.ndimage import correlate1d
+    from astrometry.util.miscutils import lanczos_filter
+    L = 3
+    Lx = lanczos_filter(L, np.arange(-L, L+1) + dx)
+    Ly = lanczos_filter(L, np.arange(-L, L+1) + dy)
+    # Normalize the Lanczos interpolants (preserve flux)
+    Lx /= Lx.sum()
+    Ly /= Ly.sum()
+    sx     = correlate1d(img, Lx, axis=1, mode='constant')
+    outimg = correlate1d(sx,  Ly, axis=0, mode='constant')
+    return outimg
+
+def plot_comparison(data_gpu, data_cpu, title="Comparison"):
+    """
+    Plots GPU data, CPU data, and the Difference side-by-side.
+    """
+    import matplotlib.pyplot as plt
+    fig, axes = plt.subplots(1, 3, figsize=(15, 5))
+
+    # 1. Plot GPU Version
+    im0 = axes[0].imshow(data_gpu, origin='lower', cmap='viridis')
+    axes[0].set_title(f'GPU {title}')
+    plt.colorbar(im0, ax=axes[0], fraction=0.046, pad=0.04)
+
+    # 2. Plot CPU Version
+    im1 = axes[1].imshow(data_cpu, origin='lower', cmap='viridis')
+    axes[1].set_title(f'CPU {title}')
+    plt.colorbar(im1, ax=axes[1], fraction=0.046, pad=0.04)
+
+    # 3. Plot Difference (Residuals)
+    # Using 'seismic' or 'RdBu' helps visualize positive/negative offsets
+    diff = data_gpu - data_cpu
+    im2 = axes[2].imshow(diff, origin='lower', cmap='seismic')
+    axes[2].set_title('Difference (GPU - CPU)')
+    plt.colorbar(im2, ax=axes[2], fraction=0.046, pad=0.04)
+
+    plt.tight_layout()
+    plt.show()
+
+def plot_one(data, title="Plot", cmap='viridis'):
+    import matplotlib.pyplot as plt
+    plt.figure(figsize=(8, 6))
+
+    # origin='lower' puts (0,0) at bottom-left
+    # interpolation='nearest' prevents blurring of pixel boundaries
+    im = plt.imshow(data, origin='lower', cmap=cmap, interpolation='nearest')
+
+    plt.title(title)
+    plt.xlabel("X [pixels]")
+    plt.ylabel("Y [pixels]")
+
+    # Add a colorbar that scales to the image height
+    plt.colorbar(im, label='Value')
+
+    plt.tight_layout()
+    plt.show()
 
 #def lanczos_shift_image_batch_gpu(imgs, dxs, dys):
 #    """Translated from lanczos_shift_image python version to GPU using cupy
@@ -53,6 +115,71 @@ if sys.version_info[0] == 2:
         outimg = outimg.reshape(oldshape)
     return outimg
 """
+
+def lanczos_shift_image_3d_gpu(imgs, dxs, dys):
+    """Translated from lanczos_shift_image python version to GPU using cupy
+        and helper functions from tractor.miscutils"""
+    import cupy as cp
+    from tractor.miscutils import gpu_lanczos_filter,batch_correlate1d_gpu_fast, batch_correlate1d_cpu_fast
+    from tractor.miscutils import batch_correlate1d_gpu, batch_correlate1d_cpu 
+    t = time.time()
+    L = 3
+    # Ensure dxs/dys are 1D for the tile operation
+    dxs = cp.atleast_1d(dxs).ravel()
+    dys = cp.atleast_1d(dys).ravel()
+    nimg = dxs.size
+
+    # 1. Coordinate Grid
+    lr = cp.arange(-L, L+1).astype(cp.float32)
+    # Use broadcasting instead of tile for efficiency
+    # Note the MINUS sign: often needed if correlating to "pull" the image
+    grid_x = lr[cp.newaxis, :] + dxs[:, cp.newaxis]
+    grid_y = lr[cp.newaxis, :] + dys[:, cp.newaxis]
+
+    # 2. Generate Filters
+    Lx = gpu_lanczos_filter(L, grid_x)
+    Ly = gpu_lanczos_filter(L, grid_y)
+    tbs[3] += time.time()-t
+    t = time.time()
+
+    # 3. Robust Normalization (avoid division by zero/epsilon)
+    Lx /= (cp.sum(Lx, axis=1, keepdims=True) + 1e-12)
+    Ly /= (cp.sum(Ly, axis=1, keepdims=True) + 1e-12)
+    tbs[4] += time.time()-t
+
+    """
+    cimgs = imgs.get()
+    clx = Lx.get()
+    cly = Ly.get()
+
+    t = time.time()
+    sx = batch_correlate1d_gpu(imgs, Lx, axis=2, mode='constant')
+    outimg1 = batch_correlate1d_gpu(sx, Ly, axis=1, mode='constant')
+    tbs[5] += time.time()-t
+
+    t = time.time()
+    try:
+        sx = batch_correlate1d_cpu(cimgs, clx, axis=2, mode='constant')
+        outimg2 = batch_correlate1d_cpu(sx, cly, axis=1, mode='constant')
+    except Exception as ex:
+        print ("Exception "+str(ex))
+    tbs[6] += time.time()-t
+
+    t = time.time()
+    sx = batch_correlate1d_cpu_fast(cimgs, clx, axis=2, mode='constant')
+    outimg3 = batch_correlate1d_cpu_fast(sx, cly, axis=1, mode='constant')
+    tbs[7] += time.time()-t
+    """
+
+    # 4. Apply 1D Separable Correlations
+    # axis=2 is Width (X), axis=1 is Height (Y)
+    t = time.time()
+    sx = batch_correlate1d_gpu_fast(imgs, Lx, axis=2, mode='constant')
+    outimg = batch_correlate1d_gpu_fast(sx, Ly, axis=1, mode='constant')
+
+    tbs[8] += time.time()-t
+
+    return outimg
 
 def lanczos_shift_image_batch_gpu(imgs, dxs, dys, chunk_size=None):
     import cupy as cp
@@ -129,7 +256,7 @@ class BatchPixelizedPSF(BaseParams, ducks.ImageCalibration):
     FIXME -- currently this class claims to have no params.
     '''
 
-    def __init__(self, psfs):
+    def __init__(self, psfs, isPointSource=False):
         '''
         Creates a new PixelizedPSF object from the given *img* (numpy
         array) image of the PSF.
@@ -146,7 +273,7 @@ class BatchPixelizedPSF(BaseParams, ducks.ImageCalibration):
         self.psfexs = []
         self.normalized = False
         for i,psf in enumerate(psfs):
-            if str(psf.pix) == 'NormalizedPixelizedPsfEx' or str(psf.pix) == 'NormalizedPixelizedPsf':
+            if hasattr(psf, 'pix') and (str(psf.pix) == 'NormalizedPixelizedPsfEx' or str(psf.pix) == 'NormalizedPixelizedPsf'):
                 self.normalized = True
             if hasattr(psf, 'psfex'):
                 self.psfexs.append(psf.psfex)
@@ -167,7 +294,9 @@ class BatchPixelizedPSF(BaseParams, ducks.ImageCalibration):
         #Now loop over psfs and copy data into one 3-d zero-padded array
         for i, psf in enumerate(psfs):
             img[i,:iH[i],:iW[i]] = psf.img
+            #print ("BATCH1", i, psf.img.max(), np.where(psf.img == psf.img.max()))
         img = cp.asarray(img)
+        #print ("H,W", H, W)
         #self.img = cp.require(img, requirements=['A'])
         self.img = img
         assert((H % 2) == 1)
@@ -183,6 +312,9 @@ class BatchPixelizedPSF(BaseParams, ducks.ImageCalibration):
             self.nativeW = int(np.ceil(self.W * self.sampling))
             self.nativeH = int(np.ceil(self.H * self.sampling))
 
+        if isPointSource:
+            print ("Point source")
+            return
         from tractor.psf import HybridPSF
         from tractor.batch_mixture_profiles import BatchMixtureOfGaussians
         psfmogs = []
@@ -348,8 +480,8 @@ class BatchPixelizedPSF(BaseParams, ducks.ImageCalibration):
         # cx,cy: coordinate of the PSF center in *pad*
         P = cp.fft.rfft2(pad)
         P = P.astype(cp.complex64)
-        del pad
         nimages, pH, pW = pad.shape
+        del pad
         v = cp.fft.rfftfreq(pW)
         w = cp.fft.fftfreq(pH)
         if (len(self.psfexs) > 0):
@@ -477,6 +609,327 @@ class BatchPixelizedPSF(BaseParams, ducks.ImageCalibration):
             #print('sum of inverse Fourier transform of PSF:', np.sum(np.fft.irfft2(sumfft, s=shape)))
         #cp.savetxt("gsumfft.txt", sumfft.ravel())
         return sumfft, (cx, cy), shape, (v, w)
+
+
+    def getBatchPointSourcePatch(self, pxs, pys, ux0, uy0, u_width, u_height):
+            """
+            Projects and shifts a point source into a 3D global canvas.
+            - pxs, pys: CuPy arrays of shape (N,) for sub-pixel positions.
+            - ux0, uy0: The top-left corner of the global canvas in pixel coordinates.
+            - u_width, u_height: Dimensions of the global canvas.
+            """
+            import cupy as cp
+
+            """
+            N = self.N
+            L = self.Lorder
+            padding = L
+
+            # 1. Allocate a padded 3D canvas on the GPU
+            ch, cw = u_height + 2 * padding, u_width + 2 * padding
+            canvas = cp.zeros((N, ch, cw), dtype=cp.float32)
+            canvas_x_start = ux0 - padding
+            canvas_y_start = uy0 - padding
+            print (f'{pxs=} {pys=} {ch=} {cw=}')
+
+            # 2. Integer shifts for placement and sub-pixel shifts for Lanczos
+            ixs = cp.round(pxs).astype(cp.int32)
+            iys = cp.round(pys).astype(cp.int32)
+            dxs = pxs - ixs
+            dys = pys - iys
+
+            # 3. Insert PSF stamps into the canvas at integer positions
+            psf_h, psf_w = self.H, self.W
+            for i in range(N):
+                ix, iy = int(ixs[i]), int(iys[i])
+                # Integer origin of PSF stamp in global coordinates
+                #x0, y0 = ix - psf_w // 2, iy - psf_h // 2
+                #x0, y0 = ix - u_width // 2, iy - u_height // 2
+                x0 = ix
+                y0 = iy
+
+                # Find the intersection of the PSF stamp and the Padded Canvas
+                # Both are in the same global coordinate system here
+                inter_x_lo = max(x0, canvas_x_start)
+                inter_x_hi = min(x0 + psf_w, canvas_x_start + cw)
+                inter_y_lo = max(y0, canvas_y_start)
+                inter_y_hi = min(y0 + psf_h, canvas_y_start + ch)
+
+                ## Intersection between PSF stamp and the padded Canvas
+                #y_lo, y_hi = max(y0, uy0 - padding), min(y0 + psf_h, uy0 + u_height + padding)
+                #x_lo, x_hi = max(x0, ux0 - padding), min(x0 + psf_w, ux0 + u_width + padding)
+                #print (f'GPU {i=} {ix=} {iy=} {x0=} {y0=} {psf_w=} {psf_h=} {ux0=} {uy0=} {padding=} {y_lo=} {y_hi=} {x_lo=} {x_hi=}')
+                print (f'GPU {i=} {ix=} {iy=} {x0=} {y0=} {psf_w=} {psf_h=} {ux0=} {uy0=} {padding=} {inter_y_lo=} {inter_y_hi=} {inter_x_lo=} {inter_x_hi=}')
+                if inter_y_hi > inter_y_lo and inter_x_hi > inter_x_lo:
+                    # 1. Local indices within the PSF stamp [0:63]
+                    ly0, ly1 = inter_y_lo - y0, inter_y_hi - y0
+                    lx0, lx1 = inter_x_lo - x0, inter_x_hi - x0
+
+                    # 2. Local indices within the Padded Canvas
+                    cy0, cy1 = inter_y_lo - canvas_y_start, inter_y_hi - canvas_y_start
+                    cx0, cx1 = inter_x_lo - canvas_x_start, inter_x_hi - canvas_x_start
+                    canvas[i, cy0:cy1, cx0:cx1] = self.img[i, ly0:ly1, lx0:lx1]
+                    print(f'GPU {cx0=} {cx1=} {cy0=} {cy1=} {lx0=} {lx1=} {ly0=} {ly1=}')
+
+            """
+            """
+                if y_hi > y_lo and x_hi > x_lo:
+                    # Relative indices for source PSF and target canvas
+                    ly0, ly1 = y_lo - y0, y_hi - y0
+                    lx0, lx1 = x_lo - x0, x_hi - x0
+                    cy0, cy1 = y_lo - (uy0 - padding), y_hi - (uy0 - padding)
+                    cx0, cx1 = x_lo - (ux0 - padding), x_hi - (ux0 - padding)
+
+                    canvas[i, cy0:cy1, cx0:cx1] = self.img[i, ly0:ly1, lx0:lx1]
+            """
+            """
+
+            # 4. Perform the 3D Batch Lanczos shift
+            shifted = lanczos_shift_image_batch_gpu(canvas, dxs, dys)
+
+            # 5. Crop back to the unpadded global canvas
+            return shifted[:, padding:-padding, padding:-padding]
+            """
+
+            #N = self.N
+            N = len(pxs)
+            print (f'{N=} {self.img.shape=}')
+            L = self.Lorder
+            padding = L
+
+            # 1. Allocate a padded 3D canvas on the GPU
+            ch, cw = u_height + 2 * padding, u_width + 2 * padding
+            canvas = cp.zeros((N, ch, cw), dtype=cp.float32)
+            psf_h, psf_w = self.H, self.W
+
+            # 2. Establish the coordinate system
+            # The CPU evaluates models at (px - x0, py - y0).
+            # To match, we must project our PSF into the patch using these coordinates.
+            # Calculate x0, y0 per star exactly as the CPU/Logs do
+            ixs_glob = cp.round(pxs).astype(cp.int32)
+            iys_glob = cp.round(pys).astype(cp.int32)
+            dxs = pxs - ixs_glob
+            dys = pys - iys_glob
+            x0s = ixs_glob - psf_w // 2
+            y0s = iys_glob - psf_h // 2
+
+
+            """
+            # These are the coordinates in the "Patch Frame" where the star is ~31.5
+            pxs_patch = pxs - x0s
+            pys_patch = pys - y0s
+
+            # Integer placement and fractional Lanczos shift
+            ixs_patch = cp.round(pxs_patch).astype(cp.int32)
+            iys_patch = cp.round(pys_patch).astype(cp.int32)
+            dxs = pxs_patch - ixs_patch
+            dys = pys_patch - iys_patch
+            print (f'{pxs=} {pys=} {ch=} {cw=}')
+            """
+
+            # However, our target canvas is still defined by (u_width, u_height).
+            # We need to account for the fact that the star at px_patch needs to be 
+            # placed in the canvas.
+            
+            #print ("CANVAS", canvas.shape)
+            t = time.time()
+            for i in range(N):
+                #print ("BATCH IMG", i, self.img[i].max(), self.img[i].shape, cp.where(self.img[i] == self.img[i].max()))
+                # 1. Coordinate of the PSF's (0,0) pixel in the x0-relative system
+                # For a 63x63 PSF and ix=31, this is 0.
+                ix, iy = int(ixs_glob[i]), int(iys_glob[i])
+                x0_psf = ix - psf_w // 2
+                y0_psf = iy - psf_h // 2
+
+                # 2. Coordinate of our Canvas (0,0) pixel in the x0-relative system
+                # ux0 is the modelmask offset. padding is the Lanczos margin.
+                x0_canvas = ux0 - padding
+                y0_canvas = uy0 - padding
+
+                # 3. Calculate the overlap using the get_overlapping_region logic
+                # We want to place the PSF (img) into the Canvas (canvas)
+                # The CPU logic: yi, yo = get_overlapping_region(target_start, target_end, img_min, img_max)
+
+                # In CPU terms: xlo = x0_canvas - x0_psf
+                # This tells us where the canvas starts relative to the PSF's 0,0
+                rel_x = x0_canvas - x0_psf
+                rel_y = y0_canvas - y0_psf
+
+                # Calculate slices for the PSF (Source) and Canvas (Destination)
+                # We use the clamped intersection logic
+                src_x0 = max(0, rel_x)
+                src_y0 = max(0, rel_y)
+
+                dst_x0 = max(0, -rel_x)
+                dst_y0 = max(0, -rel_y)
+
+                # Determine width/height of the overlap
+                overlap_w = min(psf_w, rel_x + cw) - src_x0
+                overlap_h = min(psf_h, rel_y + ch) - src_y0
+                #print (f'GPU {i=} {ix=} {iy=} {x0_psf=} {y0_psf=} {x0_canvas=} {y0_canvas=} {psf_w=} {psf_h=} {ux0=} {uy0=} {padding=} {rel_x=} {rel_y=} {src_x0=} {src_y0=} {dst_x0=} {dst_y0=}') 
+
+                if overlap_w > 0 and overlap_h > 0:
+                    lx0, lx1 = src_x0, src_x0 + overlap_w
+                    ly0, ly1 = src_y0, src_y0 + overlap_h
+
+                    cx0, cx1 = dst_x0, dst_x0 + overlap_w
+                    cy0, cy1 = dst_y0, dst_y0 + overlap_h
+
+                    canvas[i, cy0:cy1, cx0:cx1] = self.img[i, ly0:ly1, lx0:lx1]
+                    #print(f'GPU {cx0=} {cx1=} {cy0=} {cy1=} {lx0=} {lx1=} {ly0=} {ly1=}')
+                    #bx = cp.where(self.img[i] == self.img[i].max())
+                    #print (f'{bx=} {self.img[i].shape=}')
+                #if i < 2:
+                #    plot_one(canvas[i].get(), "Canvas "+str(i))
+                #    plot_one(self.img[i].get(), "Img "+str(i))
+
+            #print (f'{dxs=} {dys=}')
+            tbs[0] += time.time()-t
+            t = time.time()
+            # 4. Perform the 3D Batch Lanczos shift
+            shifted = lanczos_shift_image_3d_gpu(canvas, dxs, dys)
+            tbs[1] += time.time()-t
+            tbs[2] += 1
+            #shifted = lanczos_shift_image_batch_gpu(canvas, dxs, dys)
+            #cdx = dxs.get()
+            #cdy = dys.get()
+            #for j in range(2):
+                #sx = lanczos_shift_image(canvas[j].get(), cdx[j], cdy[j])
+                #plot_one(sx[padding:-padding, padding:-padding], "C SHIFT "+str(j))
+                #plot_one(shifted[j, padding:-padding, padding:-padding].get(), "GPU "+str(j))
+                #plot_comparison(shifted[j].get(), sx, "Lanczos comp")
+
+            # 5. Crop back to the unpadded global canvas
+            print (f'{tbs=}')
+            from tractor.psf import print_tcps
+            print_tcps()
+            return shifted[:, padding:-padding, padding:-padding]
+
+    """
+    # In batch_psf.py (class BatchPixelizedPSF)
+    def getBatchPointSourcePatch(self, pxs, pys, counts, modelMasks=None):
+        '''
+        pxs, pys, counts: 1D arrays of length N_images
+        modelMasks: list of N ModelMask objects (or None)
+        '''
+        import cupy as cp
+        from tractor.psf import lanczos_shift_image_batch_gpu
+        from astrometry.util.miscutils import get_overlapping_region
+
+        N = self.N # Number of images
+        H, W = self.H, self.W # Max PSF dimensions
+        
+        # Calculate fractional shifts
+        ixs = cp.round(pxs).astype(cp.int32)
+        iys = cp.round(pys).astype(cp.int32)
+        dxs = pxs - ixs
+        dys = pys - iys
+        
+        L = 3 # Lanczos order
+        padding = L
+
+        if modelMasks is not None:
+            # Assume point source masks are the same size for batching (typical)
+            mh, mw = modelMasks[0].shape
+            # Create a 3D canvas (N, H_mask + 2L, W_mask + 2L)
+            mm_stack = cp.zeros((N, mh + 2*padding, mw + 2*padding), dtype=cp.float32)
+            
+            for i in range(N):
+                m = modelMasks[i]
+                # PSF origin in global image
+                x0 = ixs[i] - W // 2
+                y0 = iys[i] - H // 2
+                
+                # Use overlap logic to copy the unshifted PSF into the mask canvas
+                yi, yo = get_overlapping_region(m.y0 - y0 - padding, m.y0 - y0 + mh - 1 + padding, 0, H - 1)
+                xi, xo = get_overlapping_region(m.x0 - x0 - padding, m.x0 - x0 + mw - 1 + padding, 0, W - 1)
+                
+                if len(yi) > 0 and len(xi) > 0:
+                    mm_stack[i, yo, xo] = self.img[i, yi, xi]
+            
+            # Perform 3D Lanczos shift on the entire stack in one go
+            shifted = lanczos_shift_image_batch_gpu(mm_stack, dxs, dys)
+            
+            # Crop back and apply flux counts
+            shifted = shifted[:, padding:-padding, padding:-padding]
+            shifted *= counts[:, cp.newaxis, cp.newaxis]
+            
+            return [Patch(modelMasks[i].x0, modelMasks[i].y0, shifted[i]) for i in range(N)]
+        else:
+            # No masks: Shift the full 3D padded PSF stack (self.img)
+            shifted = lanczos_shift_image_batch_gpu(self.img, dxs, dys)
+            shifted *= counts[:, cp.newaxis, cp.newaxis]
+            
+            # Origins
+            x0s = ixs - W // 2
+            y0s = iys - H // 2
+            return [Patch(x0s[i], y0s[i], shifted[i]) for i in range(N)]
+    """
+
+    """
+    def getBatchPointSourcePatch(self, pxs, pys, counts, modelMask=None, radius=None):
+        import cupy as cp
+        from astrometry.util.miscutils import get_overlapping_region
+
+        n_cand = len(pxs)
+        L = 3 # Lanczos radius
+        padding = L
+
+        # 1. Determine integer and fractional shifts
+        ixs = cp.round(cp.asarray(pxs)).astype(cp.int32)
+        iys = cp.round(cp.asarray(pys)).astype(cp.int32)
+        dxs = cp.asarray(pxs) - ixs
+        dys = cp.asarray(pys) - iys
+
+        # 2. Get PSF template
+        img = self.getImage(pxs[0], pys[0]) # (H_psf, W_psf)
+        ph, pw = img.shape
+
+        if modelMask is None:
+            # Default behavior: patch is just the size of the PSF
+            # (Similar to your existing logic)
+            psf_stack = cp.tile(cp.asarray(img), (n_cand, 1, 1))
+            shifted = lanczos_shift_image_batch_gpu(psf_stack, dxs, dys)
+            counts_gpu = cp.asarray(counts)[:, cp.newaxis, cp.newaxis]
+            return shifted * counts_gpu, ixs - pw//2, iys - ph//2
+
+        # 3. ModelMask Logic
+        mh, mw = modelMask.shape
+        mx0, my0 = modelMask.x0, modelMask.y0
+
+        # Create the 3D "canvas" with padding for Lanczos
+        # Shape: (N_candidates, mh + 2*L, mw + 2*L)
+        canvas = cp.zeros((n_cand, mh + 2*padding, mw + 2*padding), dtype=cp.float32)
+
+        for i in range(n_cand):
+            # Calculate where the PSF template sits relative to the ModelMask
+            # x0, y0 is the bottom-left of the PSF template in image coords
+            x0 = ixs[i] - pw // 2
+            y0 = iys[i] - ph // 2
+
+            # Determine overlap between PSF template and (ModelMask + Padding)
+            # This mirrors the get_overlapping_region logic in psf.py
+            yi, yo = get_overlapping_region(my0 - y0 - padding,
+                                            my0 - y0 + mh - 1 + padding,
+                                            0, ph - 1)
+            xi, xo = get_overlapping_region(mx0 - x0 - padding,
+                                            mx0 - x0 + mw - 1 + padding,
+                                            0, pw - 1)
+
+            if len(yi) > 0 and len(xi) > 0:
+                canvas[i, yo, xo] = cp.asarray(img[yi, xi])
+
+        # 4. Batch Shift the entire canvas
+        # The padding ensures the shift doesn't "lose" pixels at the mask edges
+        shifted_canvas = lanczos_shift_image_batch_gpu(canvas, dxs, dys)
+
+        # 5. Crop back to the ModelMask size and scale by flux
+        final_patches = shifted_canvas[:, padding:-padding, padding:-padding]
+        counts_gpu = cp.asarray(counts)[:, cp.newaxis, cp.newaxis]
+
+        return final_patches * counts_gpu, mx0, my0
+    """
+
 
     def getPointSourcePatch(self, px, py, minval=0., modelMask=None,
                             radius=None, **kwargs):

--- a/tractor/constrained_optimizer.py
+++ b/tractor/constrained_optimizer.py
@@ -6,7 +6,11 @@ import time
 logverb = print
 logmsg  = print
 
-tc =np.zeros(2)
+tc =np.zeros(4)
+tu = np.zeros(8)
+
+def printTiming():
+    print ("CTimes:", tc, "TU", tu)
 
 class ConstrainedOptimizer(LsqrOptimizer):
 
@@ -46,6 +50,7 @@ class ConstrainedOptimizer(LsqrOptimizer):
                 break
             if self.stepLimited and dlnp <= dchisq_limited:
                 break
+        tx = time.time()
         R.update(steps=step)
         R.update(hit_limit=self.last_step_hit_limit,
                  ever_hit_limit=self.hit_limit)
@@ -54,19 +59,31 @@ class ConstrainedOptimizer(LsqrOptimizer):
         return R
 
     def tryUpdates(self, tractor, X, alphas=None, check_step=None):
+        #print ("TRY UPDATES", X.shape)
+        t = time.time()
+        tx = time.time()
         p_best = tractor.getParams()
+        #print (f'{p_best=}')
+        tu[0] += time.time()-tx
+        tx = time.time()
         logprob_before = tractor.getLogProb()
+        #print (f'{logprob_before=}')
         logprob_best = logprob_before
         alpha_best = None
+        tu[1] += time.time()-tx
+        tx = time.time()
 
         # Get lists of alpha values and parameters to try
         steps = self.getParameterSteps(tractor, X, alphas)
+        #print (f'{steps=}')
+        tu[2] += time.time()-tx
 
         if len(steps) == 0:
             self.last_step_hit_limit = True
             self.hit_limit = True
 
         for alpha, p, step_limit, hit_limit in steps:
+            tx = time.time()
             if hit_limit:
                 self.hit_limit = True
 
@@ -94,11 +111,19 @@ class ConstrainedOptimizer(LsqrOptimizer):
                 alpha_best = alpha
                 logprob_best = logprob
                 p_best = p
+            tu[3] += time.time()-tx
 
+        tx = time.time()
         tractor.setParams(p_best)
         #print ("Pbest", p_best)
         #print ("LOGPROB", logprob_best, logprob_before)
         #print ("ALPHA", alpha_best, self.hit_limit, self.last_step_hit_limit)
+        tc[3] += time.time()-t
+        tu[4] += time.time()-tx
+        #print (f'{tc=}')
+        #print (f'{tu=}')
+        #import sys
+        #sys.exit(0)
         if alpha_best is None:
             return 0., 0.
 
@@ -179,4 +204,5 @@ class ConstrainedOptimizer(LsqrOptimizer):
 
             if do_break:
                 break
+        #print ("CONSTRAINED steps = ", results)
         return results

--- a/tractor/dense_optimizer.py
+++ b/tractor/dense_optimizer.py
@@ -4,6 +4,8 @@ from tractor.engine import logverb
 from tractor.constrained_optimizer import ConstrainedOptimizer
 
 from numpy.linalg import lstsq, LinAlgError
+import time
+td = np.zeros(2)
 
 # from astrometry.util.plotutils import PlotSequence
 # ps = PlotSequence('opt')
@@ -21,6 +23,7 @@ class ConstrainedDenseOptimizer(ConstrainedOptimizer):
                            shared_params=True,
                            get_A_matrix=False):
 
+        t = time.time()
         #print('ConstrainedDenseOptimizer.getUpdateDirection: shared_params=', shared_params,
         #      'scales_only=', scales_only, 'damp', damp, 'variance', variance)
         #print ("TIM - dense - ", tractor.images)
@@ -257,6 +260,8 @@ class ConstrainedDenseOptimizer(ConstrainedOptimizer):
             X /= colscales
 
         #print ("X DENSE:", X)
+        td[0] += time.time()-t
+        print (f'{td=}')
         if False:
             print('Returning:  ', X)
             Xold = super(ConstrainedDenseOptimizer, self).getUpdateDirection(

--- a/tractor/engine.py
+++ b/tractor/engine.py
@@ -19,6 +19,13 @@ from tractor.image import Image
 from tractor.utils import savetxt_cpu_append
 
 import time
+tchi = np.zeros(10)
+tmod = np.zeros(6)
+teng = np.zeros(6)
+tlog = np.zeros(6)
+
+def printTiming():
+    print (f'EngTimes: {tchi=} {tmod=} {teng=} {tlog=}')
 
 logger = logging.getLogger('tractor.engine')
 def logverb(*args):
@@ -38,6 +45,59 @@ def set_fp_err():
         np.seterr(**olderr)
     '''
     return np.seterr(all='raise')
+
+def get_global_extent(tims, ux0, uy0, ux1, uy1):
+    """
+    Standardizes the image info based on a pre-calculated global box.
+    This ensures we don't 'shrink' our view based on masks.
+    """
+    image_info = []
+    for tim in tims:
+        img_h, img_w = tim.shape
+        # The intersection of the global box and this specific image
+        y_start = max(uy0, 0)
+        y_end   = min(uy1, img_h)
+        x_start = max(ux0, 0)
+        x_end   = min(ux1, img_w)
+
+        # We store the absolute image coords (ly) and the stack offsets (gy)
+        # th, tw here represent the 'actual' overlapping area
+        th = max(0, y_end - y_start)
+        tw = max(0, x_end - x_start)
+        image_info.append((x_start, y_start, th, tw))
+
+    return image_info
+
+def get_global_extent_mm(tims, modelMasks=None):
+    all_x0, all_x1, all_y0, all_y1 = [], [], [], []
+    image_info = []
+
+    if modelMasks is None:
+        modelMasks = [None] * len(tims)
+
+    for tim, mask in zip(tims, modelMasks):
+        if mask is not None:
+            tx0, ty0 = mask.x0, mask.y0
+            th, tw = mask.shape
+        else:
+            # Full image fallback: No x0/y0 on tim, so it's 0,0 relative to itself
+            tx0, ty0 = 0, 0
+            th, tw = tim.shape
+
+        all_x0.append(tx0)
+        all_x1.append(tx0 + tw)
+        all_y0.append(ty0)
+        all_y1.append(ty0 + th)
+        image_info.append((tx0, ty0, th, tw))
+
+    ux0, ux1 = min(all_x0), max(all_x1)
+    uy0, uy1 = min(all_y0), max(all_y1)
+    ux0 = int(ux0)
+    ux1 = int(ux1)
+    uy0 = int(uy0)
+    uy1 = int(uy1)
+
+    return (ux0, ux1, uy0, uy1), image_info
 
 
 class Catalog(MultiParams):
@@ -320,7 +380,7 @@ class Tractor(MultiParams):
         if not self.isParamFrozen('images'):
             for i in self.images.getThawedParamIndices():
                 img = self.images[i]
-                #print ("IMG", img)
+                #print ("IMG", i, img)
                 derivs = img.getParamDerivatives(self, allsrcs, **kw)
                 mod0 = None
                 for di, deriv in enumerate(derivs):
@@ -336,20 +396,26 @@ class Tractor(MultiParams):
                         deriv = Patch(0, 0, (mod - mod0) / stepsizes[di])
                         deriv.name = 'd(im%i)/d(%s)' % (i, paramnames[di])
                     allderivs.append([(deriv, img)])
+                    #np.savetxt('cpu_d_'+str(di)+'.txt', deriv.patch)
                 del mod0
 
-        #print ("TEST2")
+        #print ("TEST2", len(self.images))
         for src in srcs:
             srcderivs = [[] for i in range(src.numberOfParams())]
             for img in self.images:
                 #print ("IMG2", img)
                 derivs = self._getSourceDerivatives(src, img, **kwargs)
                 for k, deriv in enumerate(derivs):
+                    #print ("K", k)
                     if deriv is None:
+                        #print ("Deriv is None")
                         continue
                     srcderivs[k].append((deriv, img))
+                    #np.savetxt('cpu_sd_'+str(k)+'.txt', deriv.patch)
             allderivs.extend(srcderivs)
         #print('allderivs:', len(allderivs))
+        #for i in range(len(allderivs)):
+        #    print ("I", i, len(allderivs[i]))
         #print('N params:', self.numberOfParams())
 
         assert(len(allderivs) == self.numberOfParams())
@@ -454,21 +520,41 @@ class Tractor(MultiParams):
         then only those sources will be rendered into the image.
         Otherwise, the whole catalog will be.
         '''
+        t0 = time.time()
         if _isint(img):
             img = self.getImage(img)
         mod = np.zeros(img.getModelShape(), self.modtype)
         if sky:
             img.getSky().addTo(mod)
+            #print ("SKYC", mod.max())
         if srcs is None:
             srcs = self.catalog
         for src in srcs:
             if src is None:
                 continue
+            t = time.time()
             patch = self.getModelPatch(img, src, minsb=minsb, **kwargs)
+            tmod[1] += time.time()-t
             if patch is None:
                 continue
+            #print (f'{patch.patch.shape=} {patch.patch.max()=} {mod.shape=}')
             patch.addTo(mod)
+            #print ("MOD CPU ", mod.max()) 
+        tmod[0] += time.time()-t0
         return mod
+
+    def getModelSubImageOneSource(self, img, src=None, sky=True, minsb=None, **kwargs):
+        t = time.time()
+        if src is None:
+            src = self.catalog[0]
+        patch = self.getModelPatch(img, src, minsb=minsb, **kwargs)
+        if patch is None:
+            #teng[4] += time.time()-t
+            return None
+        if sky:
+            img.getSky().addTo(patch.patch)
+        #teng[4] += time.time()-t
+        return patch.patch
 
     def getModelImages(self, **kwargs):
         for img in self.images:
@@ -482,9 +568,187 @@ class Tractor(MultiParams):
         for img in self.images:
             yield self.getChiImage(img=img, **kwargs)
 
+    def getChiSquaredsBatch(self, candidate_params, use_gpu=True, **kwargs):
+        import cupy as cp
+        n_cand = len(candidate_params)
+        chisqs = cp.zeros(n_cand, dtype=cp.float64)
+        
+        # Store current state to restore later
+        p0 = self.getParams()
+        # Assume we are optimizing the first source for the line search
+        src = self.getCatalog()[0]
+        
+        # Pre-fetch modelMask if provided in kwargs
+        modelMask = kwargs.get('modelMask', None)
+
+        for img in self.getImages():
+            # Get data and inverse error on GPU
+            data_gpu = img.getImage(use_gpu=use_gpu)
+            ie_gpu = img.getInvError(use_gpu=use_gpu)
+            wcs = img.getWcs()
+            photocal = img.getPhotoCal()
+            psf = img.getPsf()
+            
+            # 1. Collect pixel coords and counts for all candidates
+            pxs, pys, counts = [], [], []
+            for p in candidate_params:
+                self.setParams(p)
+                px, py = wcs.positionToPixel(src.getPosition(), src)
+                cnt = photocal.brightnessToCounts(src.getBrightness())
+                pxs.append(px)
+                pys.append(py)
+                counts.append(cnt)
+                
+            # 2. Call the batched PSF method
+            # This returns (N, H, W) patches and the origin (x0, y0)
+            patches, x0, y0 = psf.getBatchPointSourcePatch(pxs, pys, counts, 
+                                                           modelMask=modelMask)
+            
+            # 3. Compute Chi^2 contribution for this image
+            ph, pw = patches.shape[1], patches.shape[2]
+            
+            # Extract corresponding ROI from the data/ie images
+            # If modelMask was used, x0/y0 are already the mask's origin
+            d_cut = data_gpu[y0:y0+ph, x0:x0+pw]
+            ie_cut = ie_gpu[y0:y0+ph, x0:x0+pw]
+            
+            # Vectorized chi calculation: (Data - Model) * InvErr
+            # CuPy handles the (H, W) vs (N, H, W) broadcasting
+            diffs = (d_cut - patches) * ie_cut
+            chisqs += cp.sum(diffs**2, axis=(1, 2))
+            
+        self.setParams(p0)
+        return chisqs
+
+    def get_3d_stack_InvErrors(self, tims=None):
+        if tims is None:
+            tims = self.images
+        
+        # 1. Automatically find the canvas size needed
+        all_h = [t.shape[0] for t in tims]
+        all_w = [t.shape[1] for t in tims]
+        max_h, max_w = max(all_h), max(all_w)
+        
+        # 2. Call your existing method with the 'Full' bounds
+        # Since ux0, uy0 = 0, the stack offsets gy0, gx0 will just be ty0, tx0
+        stack = self.getBatchInvErrors(ux0=0, uy0=0, ux1=max_w, uy1=max_h, tims=tims)
+        #for i in range(len(tims)):
+        #    print (f'{i=} ie {stack[i].max()=}')
+        
+        return stack
+
+    def get_3d_stack_Data(self, tims=None):
+        if tims is None:
+            tims = self.images
+
+        # 1. Automatically find the canvas size needed
+        all_h = [t.shape[0] for t in tims]
+        all_w = [t.shape[1] for t in tims]
+        max_h, max_w = max(all_h), max(all_w)
+            
+        # 2. Call your existing method with the 'Full' bounds
+        # Since ux0, uy0 = 0, the stack offsets gy0, gx0 will just be ty0, tx0
+        stack = self.getBatchData(ux0=0, uy0=0, ux1=max_w, uy1=max_h, tims=tims)
+        #for i in range(len(tims)):
+        #    print (f'{i=} data {stack[i].max()=}')
+            
+        return stack 
+
+    def get_3d_stack_Model(self, tims=None, src=None, sky=True, minsb=None, **kwargs):
+        import cupy as cp
+        from tractor.sky import NullSky, ConstantSky
+        if tims is None:
+            tims = self.images
+        if src is None:
+            src = self.catalog[0]
+
+        # 1. Automatically find the canvas size needed
+        all_h = [t.shape[0] for t in tims]
+        all_w = [t.shape[1] for t in tims]
+        max_h, max_w = max(all_h), max(all_w)
+
+        """
+        stack = np.zeros((max_h, max_w), dtype=tims[0].data.dtype)
+        for i, img in enumerate(tims):
+            cmodi = self.getModelImage(img)
+            #patch = self.getModelPatch(img, src, minsb=minsb, **kwargs)
+            #if patch is None:
+            #    continue
+            #print ("SHAPES", img.shape, cmodi.shape, patch.patch.shape)
+            #if sky:
+            #    thisSky = img.getSky()
+            #    if not isinstance(thisSky, NullSky):
+            #        thisSky.addTo(patch.patch)
+            #stack[i:all_h[i], :all_w[i]] = patch.patch
+            stack[i:all_h[i], :all_w[i]] = cmodi
+        """
+        stack = self.getBatchModel(ux0=0, uy0=0, ux1=max_w, uy1=max_h, tims=tims)
+        return cp.asarray(stack)
+
+    def get_3d_stack_Chi(self, tims=None, ie=None, im=None, mod=None):
+        import cupy as cp
+        if tims is None:
+            tims = self.images
+
+        if ie is None:
+            ie = self.get_3d_stack_InvErrors(tims)
+        if im is None:
+            im = self.get_3d_stack_Data(tims)
+        if mod is None:
+            mod = self.get_3d_stack_Model(tims)
+
+        stack = (im-mod)*ie
+        return stack
+
+    def getChiImageStack(self, use_gpu=True, modelMask=None):
+        """
+        Returns a 3D CuPy tensor (N_images, H_mask, W_mask) of chi values.
+        """
+        import cupy as cp
+        from tractor.batch_psf import BatchPixelizedPSF
+        
+        # 1. Gather metadata for the stack
+        tims = self.getImages()
+        psfs = [tim.getPsf() for tim in tims]
+        src = self.getCatalog()[0] # Focusing on the point source
+        
+        # 2. Initialize the Batch PSF with the stack of PSFs
+        batch_psf = BatchPixelizedPSF(psfs)
+        
+        # 3. Get positions and counts for all images
+        # We do this on CPU/NumPy and then move to GPU
+        pxs, pys, counts = [], [], []
+        for tim in tims:
+            px, py = tim.getWcs().positionToPixel(src.getPosition(), src)
+            cnt = tim.getPhotoCal().brightnessToCounts(src.getBrightness())
+            pxs.append(px)
+            pys.append(py)
+            counts.append(cnt)
+        
+        # 4. Get the 3D Model Patch Stack
+        # This calls your Lanczos-shifted batch logic
+        model_stack, mx0, my0 = batch_psf.getBatchPointSourcePatch(
+            cp.array(pxs), cp.array(pys), cp.array(counts), modelMask=modelMask
+        )
+        
+        # 5. Extract Data and InvErr stacks from the images
+        # We crop the global images to match the model_stack's footprint
+        mh, mw = model_stack.shape[1:]
+        
+        # Stack the crops: (N_images, H_mask, W_mask)
+        data_stack = cp.stack([tim.getImage(use_gpu=False)[my0:my0+mh, mx0:mx0+mw] for tim in tims])
+        ie_stack = cp.stack([tim.getInvError(use_gpu=True)[my0:my0+mh, mx0:mx0+mw] for tim in tims])
+        
+        # 6. Calculate Chi Stack: (Data - Model) * InvError
+        chi_stack = (data_stack - model_stack) * ie_stack
+        
+        return chi_stack
+
     def getChiImageGPU(self, imgi=-1, img=None, srcs=None, minsb=0., **kwargs):
         import cupy as cp
+        t = time.time()
         gi = cp.asarray(self.getChiImage(imgi, img, srcs, minsb, **kwargs))
+        tchi[6] += time.time()-t
         """
         TODO: In future use factored_optimizer helpers to get chi2
         if img is None:
@@ -502,11 +766,20 @@ class Tractor(MultiParams):
         """
         return gi
 
-    def getChiImage(self, imgi=-1, img=None, srcs=None, minsb=0., **kwargs):
+    def getChiImage(self, imgi=-1, img=None, srcs=None, minsb=0., use_gpu=False, **kwargs):
+        t = time.time()
         if img is None:
             img = self.getImage(imgi)
         mod = self.getModelImage(img, srcs=srcs, minsb=minsb, **kwargs)
+        tchi[7] += time.time()-t
+        t = time.time()
+        if use_gpu:
+            import cupy as cp
+            chi = (img.getImage(use_gpu=True)-cp.asarray(mod))*img.getInvError(use_gpu=True)
+            tchi[8] += time.time()-t
+            return chi
         chi = (img.getImage() - mod) * img.getInvError()
+        tchi[9] += time.time()-t
         #savetxt_cpu_append('cmod.txt', mod)
         #savetxt_cpu_append('cie.txt', img.getInvError())
         #savetxt_cpu_append('cpix.txt', img.getImage())
@@ -525,16 +798,49 @@ class Tractor(MultiParams):
             print('psf:', img.getPsf())
         return chi
 
-    def getLogLikelihoodGPU(self, **kwargs):
-        chisq = 0.
-        for i, chi in enumerate(self.getChiImagesGPU(**kwargs)):
-            chisq += (chi.astype(float) ** 2).sum()
+    def getLogLikelihoodBatch(self, candidate_params, bounds, use_gpu=True, **kwargs):
+        """
+        candidate_params: List of parameter arrays (one for each alpha)
+        Returns: cp.array of shape (len(candidate_params),)
+        """
+        import cupy as cp
+        # 1. Get the 4D Chi tensor from your new batch engine
+        # Expected shape: (N_candidates, N_images, H, W) or (N_candidates, Total_Pixels)
+        t = time.time()
+        (ux0, ux1, uy0, uy1) = bounds 
+        chi_batch = self.getBatchChiImages(
+            ux0=ux0, uy0=uy0, ux1=ux1, uy1=uy1,
+            candidate_params=candidate_params, 
+            use_gpu=use_gpu, 
+            #batch_psf=self.batch_psf,
+            **kwargs
+        )
+        """
+        print (f'{chi_batch.shape=}')
+        for i in range(chi_batch.shape[0]):
+            print (f'{candidate_params[i]=}')
+            for j in range(chi_batch.shape[1]):
+                print (f'{i=} {j=} {chi_batch[i][j].max()=} {chi_batch[i][j].shape=}') 
+        """
+        
+        # 2. Compute -0.5 * sum(chi^2) across all images/pixels for EACH candidate
+        # We sum across all axes EXCEPT the first one (the candidate index)
+        axes_to_sum = tuple(range(1, chi_batch.ndim))
+        chisq = cp.sum(chi_batch**2, axis=axes_to_sum, dtype=cp.float64)
+        #print ("LOGL", chisq.shape, chi_batch.shape)
+        #print (f'{chisq=}')
+        tlog[1] += time.time()-t
+        
         return -0.5 * chisq
 
     def getLogLikelihood(self, **kwargs):
+        t = time.time()
         chisq = 0.
+        #print ("LEN IMAGES", len(self.images))
         for i, chi in enumerate(self.getChiImages(**kwargs)):
             chisq += (chi.astype(float) ** 2).sum()
+            #print (f'{i=} {chisq=} {chi.max()=} {chi.shape=}')
+        tlog[0] += time.time()-t
         return -0.5 * chisq
 
     def getLogProbGPU(self, **kwargs):
@@ -558,14 +864,62 @@ class Tractor(MultiParams):
             return -np.inf
         return lnp
 
+    def getLogProbBatch(self, candidate_params, bounds=None, use_gpu=True, ie_stack=None, **kwargs):
+        '''
+        Return the posterior log PDF for a batch of candidates.
+        Evaluates LogPrior (CPU) + LogLikelihood (GPU).
+        '''
+        import cupy as cp
+        t = time.time()
+        if bounds is None:
+            bounds = get_global_extent_mm(self.images)[0] 
+        if ie_stack is None:
+            (ux0, uy0, ux1, uy1) = bounds
+            tims = self.images
+            ie_stack = self.getBatchInvErrors(ux0, uy0, ux1, uy1, use_gpu=use_gpu, tims=tims)
+        n_cand = len(candidate_params)
+        #print (f'{candidate_params=}')
+        
+        # 1. Evaluate Priors (CPU-bound, usually very fast)
+        p0 = self.getParams()
+        priors = []
+        for p in candidate_params:
+            self.setParams(p)
+            priors.append(self.getLogPrior())
+        priors = np.array(priors)
+        self.setParams(p0) # Restore immediately
+        
+        # Identify candidates that are physically possible
+        valid_mask = np.isfinite(priors)
+        if not np.any(valid_mask):
+            print ("INVALID")
+            return cp.asarray(priors)
+
+        # 2. Evaluate Likelihood for valid candidates only
+        # (Optional: You could filter candidate_params here to save GPU time,
+        # but for small N like 13, it's often faster to just run the batch)
+        lnl = self.getLogLikelihoodBatch(candidate_params, bounds=bounds, use_gpu=use_gpu, ie_stack=ie_stack, **kwargs)
+        #print (f'{lnl=}')
+        
+        # 3. Combine
+        lnp = cp.asarray(priors)
+        lnp[valid_mask] += lnl
+        #print (f'{lnp=}')
+        tlog[3] += time.time()-t
+        
+        return lnp
+
     def getLogProb(self, **kwargs):
         '''
         Return the posterior log PDF, evaluated at the current parameters.
         '''
+        t = time.time()
         lnprior = self.getLogPrior()
+        #print (f'{lnprior=}')
         if lnprior == -np.inf:
             return lnprior
         lnl = self.getLogLikelihood(**kwargs)
+        #print (f'{lnl=}')
         #print ("TL:", tl, gcl, cl, "GI", gi)
         lnp = lnprior + lnl
         #print ("LP", lnprior, "LNL", lnl, "LNP", lnp)
@@ -576,4 +930,428 @@ class Tractor(MultiParams):
             print('log likelihood:', lnl)
             print('log prior:', lnprior)
             return -np.inf
+        tlog[2] += time.time()-t
+        #print (f'{teng=}')
+        #print (f'{tchi=}')
+        #print (f'{tmod=}')
+        #print (f'{tlog=}')
         return lnp
+
+#    def getBatchInvErrors(self, use_gpu=True, modelMasks=None, tims=None):
+    def getBatchInvErrors(self, ux0, uy0, ux1, uy1, use_gpu=True, tims=None, modelMasks=None):
+        import cupy as cp
+        t = time.time()
+        if tims is None:
+            tims = self.getImages()
+        #if modelMasks is None:
+        #    modelMasks = [self._getModelMaskFor(tim, self.catalog[0]) for tim in tims]
+
+        #(ux0, ux1, uy0, uy1), img_info = get_global_extent(tims, modelMasks)
+        #mm_coords, mm_info = get_global_extent_mm(tims, modelMasks)
+        img_info = get_global_extent(tims, ux0, uy0, ux1, uy1)
+
+        #print (f'{ux0=} {ux1=} {uy0=} {uy1=} {img_info=}')
+        #print (f'{mm_coords=} {mm_info=}')
+        uH, uW = uy1 - uy0, ux1 - ux0
+        stack = cp.zeros((len(tims), uH, uW), dtype=cp.float32)
+        #print (f'{stack.shape=}')
+
+        for i, (tim, (tx0, ty0, th, tw)) in enumerate(zip(tims, img_info)):
+            ie = tim.getInvError(use_gpu=True)
+            if not isinstance(ie, cp.ndarray): ie = cp.asarray(ie)
+
+            # Local indices: since tim has no x0/y0, we pull from its (0,0)
+            # but if it's a mask, tx0/ty0 ARE the local offsets we need
+            # relative to the tim's internal buffer.
+            ly0, ly1 = ty0, ty0 + th
+            lx0, lx1 = tx0, tx0 + tw
+
+            # Global indices relative to the 3D stack
+            gy0, gy1 = ty0 - uy0, ty0 + th - uy0
+            gx0, gx1 = tx0 - ux0, tx0 + tw - ux0
+
+            #print (f"IE {i=} {ie.max()=} {ie.shape=} {gy0=} {gy1=} {gx0=} {gx1=} {ly0=} {ly1=} {lx0=} {lx1=}")
+            #print (cp.where(ie == ie.max()))
+
+            stack[i, gy0:gy1, gx0:gx1] = ie[ly0:ly1, lx0:lx1]
+            #print (f"IE {stack[i].max()=}")
+        teng[0] += time.time()-t
+        #print (f'{teng=}')
+        return stack
+
+    def getBatchData(self, ux0, uy0, ux1, uy1, use_gpu=True, tims=None, modelMasks=None):
+        import cupy as cp
+        t = time.time()
+        if tims is None:
+            tims = self.getImages()
+        #if modelMasks is None:
+        #    modelMasks = [self._getModelMaskFor(tim, self.catalog[0]) for tim in tims]
+
+        #(ux0, ux1, uy0, uy1), img_info = get_global_extent(tims, modelMasks)
+        #mm_coords, mm_info = get_global_extent_mm(tims, modelMasks)
+        img_info = get_global_extent(tims, ux0, uy0, ux1, uy1)
+
+        #print (f'{ux0=} {ux1=} {uy0=} {uy1=} {img_info=}')
+        #print (f'{mm_coords=} {mm_info=}')
+        uH, uW = uy1 - uy0, ux1 - ux0
+        stack = cp.zeros((len(tims), uH, uW), dtype=cp.float32)
+        #print (f'{stack.shape=}')
+
+        for i, (tim, (tx0, ty0, th, tw)) in enumerate(zip(tims, img_info)):
+            im = tim.getImage(use_gpu=True)
+            if not isinstance(im, cp.ndarray): im = cp.asarray(im)
+
+            # Local indices: since tim has no x0/y0, we pull from its (0,0)
+            # but if it's a mask, tx0/ty0 ARE the local offsets we need
+            # relative to the tim's internal buffer.
+            ly0, ly1 = ty0, ty0 + th
+            lx0, lx1 = tx0, tx0 + tw
+
+            # Global indices relative to the 3D stack
+            gy0, gy1 = ty0 - uy0, ty0 + th - uy0
+            gx0, gx1 = tx0 - ux0, tx0 + tw - ux0
+
+            stack[i, gy0:gy1, gx0:gx1] = im[ly0:ly1, lx0:lx1]
+            #print (f"DATA {stack[i].max()=}")
+        #teng[0] += time.time()-t
+        #print (f'{teng=}')
+        return stack
+
+    def getBatchModel(self, ux0, uy0, ux1, uy1, use_gpu=True, tims=None, modelMasks=None):
+        import cupy as cp
+        t = time.time()
+        if tims is None:
+            tims = self.getImages()
+        #if modelMasks is None:
+        #    modelMasks = [self._getModelMaskFor(tim, self.catalog[0]) for tim in tims]
+                
+        #(ux0, ux1, uy0, uy1), img_info = get_global_extent(tims, modelMasks)
+        #mm_coords, mm_info = get_global_extent_mm(tims, modelMasks)
+        img_info = get_global_extent(tims, ux0, uy0, ux1, uy1)
+
+        #print (f'{ux0=} {ux1=} {uy0=} {uy1=} {img_info=}')
+        #print (f'{mm_coords=} {mm_info=}')
+        uH, uW = uy1 - uy0, ux1 - ux0
+        stack = cp.zeros((len(tims), uH, uW), dtype=cp.float32)
+        #print (f'{stack.shape=}')
+
+        for i, (tim, (tx0, ty0, th, tw)) in enumerate(zip(tims, img_info)):
+            cmodi = self.getModelImage(tim)
+            if not isinstance(cmodi, cp.ndarray): cmodi = cp.asarray(cmodi)
+
+            # Local indices: since tim has no x0/y0, we pull from its (0,0)
+            # but if it's a mask, tx0/ty0 ARE the local offsets we need
+            # relative to the tim's internal buffer.
+            ly0, ly1 = ty0, ty0 + th
+            lx0, lx1 = tx0, tx0 + tw
+            
+            # Global indices relative to the 3D stack
+            gy0, gy1 = ty0 - uy0, ty0 + th - uy0
+            gx0, gx1 = tx0 - ux0, tx0 + tw - ux0
+
+            stack[i, gy0:gy1, gx0:gx1] = cmodi[ly0:ly1, lx0:lx1]
+            #print (f"DATA {stack[i].max()=}")
+        #teng[0] += time.time()-t
+        #print (f'{teng=}')
+        return stack
+
+
+#    def getBatchModelImage(self, use_gpu=True, batch_psf=None, modelMasks=None, tims=None):
+    def getBatchModelImage(self, ux0, uy0, ux1, uy1, use_gpu=True, batch_psf=None, tims=None):
+        import cupy as cp
+        import numpy as np
+        from tractor.sky import NullSky, ConstantSky
+
+        t = time.time()
+        #if tims is None:
+        #    tims = self.getImages()
+        #if modelMasks is None:
+        #    modelMasks = [self._getModelMaskFor(tim, self.catalog[0]) for tim in tims]
+        #(ux0, ux1, uy0, uy1), img_info = get_global_extent(tims, modelMasks)
+        img_info = get_global_extent(tims, ux0, uy0, ux1, uy1)
+        uH, uW = uy1 - uy0, ux1 - ux0
+        # Initialize 3D stack on GPU
+        model_stack = cp.zeros((len(tims), uH, uW), dtype=cp.float32)
+
+        # 1. Add Sky
+        for i, (tim, (tx0, ty0, th, tw)) in enumerate(zip(tims, img_info)):
+            sky = tim.getSky()
+            if isinstance(sky, NullSky):
+                continue
+
+            gy0, gy1 = ty0 - uy0, ty0 + th - uy0
+            gx0, gx1 = tx0 - ux0, tx0 + tw - ux0
+            #print (f'SKY {gx0=} {gx1=} {gy0=} {gy1=} {th=} {tw=} {ux0=} {uy0=}')
+
+            if isinstance(sky, ConstantSky):
+                val = sky.getConstant()
+                if val != 0:
+                    model_stack[i, gy0:gy1, gx0:gx1] += val
+            else:
+                temp_sky = np.zeros(tim.shape, dtype=np.float32)
+                sky.addTo(temp_sky)
+                model_stack[i, gy0:gy1, gx0:gx1] += cp.asarray(temp_sky[ty0:ty0+th, tx0:tx0+tw])
+        tmod[2] += time.time()-t
+        #print ("MOD SKY", model_stack.max(), model_stack.sum())
+
+        # 2. Add Sources
+        for src in self.catalog:
+            t = time.time()
+            gx_list, gy_list, counts = [], [], cp.zeros(len(tims), dtype=cp.float32)
+            for i, tim in enumerate(tims):
+                # Pixel position on the tim
+                px, py = tim.getWcs().positionToPixel(src.getPosition())
+                #print (f'GPUX {i=} {px=} {py=} {tim=} {src.getPosition()=}')
+
+                # Global coordinate is just px/py because tim starts at 0,0
+                gx_list.append(px)
+                gy_list.append(py)
+
+                if (0 <= px < tim.shape[1] and 0 <= py < tim.shape[0]):
+                    counts[i] = tim.getPhotoCal().brightnessToCounts(src.getBrightness())
+
+            tmod[3] += time.time()-t
+            t = time.time()
+            if cp.all(counts == 0): continue
+
+            #print (f'{gx_list=} {gy_list=}')
+            #print (f'SRC {ux0=} {uy0=} {uW=} {uH=}')
+            src_3d = batch_psf.getBatchPointSourcePatch(
+                cp.array(gx_list), cp.array(gy_list),
+                ux0, uy0, uW, uH
+            )
+            model_stack += src_3d * counts[:, cp.newaxis, cp.newaxis]
+            tmod[4] += time.time()-t
+            """
+            for i, tim in enumerate(tims):
+                mod1 = self.getModelImage(img=tim)
+                print (f'MOD1 {mod1.max()=} {mod1.shape=} {mod1.sum()=}')
+                print (np.where(mod1 == mod1.max()))
+                print (f'MOD STACK {i=} {model_stack[i].max()=} {model_stack[i].shape=} {model_stack[i].sum()=}')
+                print (cp.where(model_stack[i] == model_stack[i].max()))
+            """
+
+        return model_stack
+
+    def getBatchChiImages(self, ux0, uy0, ux1, uy1, use_gpu=True, batch_psf=None, tims=None, ie_stack=None, candidate_params=None):
+        import cupy as cp
+        import time
+        t = time.time()
+        tx = time.time()
+        if tims is None:
+            tims = self.getImages()
+        Nimages = len(tims)
+
+        # 2. Get the global canvas bounds and the per-image offsets/shapes
+        #(ux0, ux1, uy0, uy1), img_info = get_global_extent(tims, modelMasks)
+        img_info = get_global_extent(tims, ux0, uy0, ux1, uy1)
+        uH, uW = uy1 - uy0, ux1 - ux0
+
+        # 3. Initialize stacks for Data and Inverse Variance
+        data_stack = cp.zeros((len(tims), uH, uW), dtype=cp.float64)
+        #ie_stack = cp.zeros((len(tims), uH, uW), dtype=cp.float32)
+
+        for i, (tim, (tx0, ty0, th, tw)) in enumerate(zip(tims, img_info)):
+            # Global indices relative to the 3D stack origin (ux0, uy0)
+            gy0, gy1 = ty0 - uy0, ty0 + th - uy0
+            gx0, gx1 = tx0 - ux0, tx0 + tw - ux0
+
+            # Local indices relative to the tim's internal buffer (starting at 0,0)
+            # If tx0/ty0 came from a mask, they represent the offset within the tim.
+            ly0, ly1 = ty0, ty0 + th
+            lx0, lx1 = tx0, tx0 + tw
+            # Populate the stacks
+            data_stack[i, gy0:gy1, gx0:gx1] = cp.asarray(tim.getImage(use_gpu=True)[ly0:ly1, lx0:lx1])
+
+        tchi[1] += time.time()-t
+        t = time.time()
+        if ie_stack is None:
+            ie_stack = self.getBatchInvErrors(ux0, uy0, ux1, uy1, use_gpu=use_gpu, tims=tims)
+        tchi[2] += time.time()-t
+        t = time.time()
+
+        # 2. Model Stack Generation
+        if candidate_params is not None:
+            # 4D PATH: (N_alphas, N_images, uH, uW)
+            n_alphas = len(candidate_params)
+            p_initial = self.getParams()
+            
+            # Pre-allocate 4D on CPU for the fast fill
+            cmod_stack_4d = np.zeros((n_alphas, Nimages, uH, uW), dtype=np.float64)
+            
+            for a_idx, p_trial in enumerate(candidate_params):
+                self.setParams(p_trial) # Temporary set to render
+                for i, (tim, (tx0, ty0, th, tw)) in enumerate(zip(tims, img_info)):
+                    gy0, gy1 = ty0 - uy0, ty0 + th - uy0
+                    gx0, gx1 = tx0 - ux0, tx0 + tw - ux0
+                    cmod_stack_4d[a_idx, i, gy0:gy1, gx0:gx1] = self.getModelImage(tim)[ty0:ty0+th, tx0:tx0+tw]
+            
+            self.setParams(p_initial) # Restore state
+            model_stack = cp.asarray(cmod_stack_4d)
+            
+            # Broadcoast Data and IE over the Alpha dimension
+            # (1, N_img, H, W) is broadcast against (N_alpha, N_img, H, W)
+            chi = (data_stack[cp.newaxis, ...] - model_stack) * ie_stack[cp.newaxis, ...]
+            tchi[3] += time.time()-t
+            tchi[0] += time.time()-tx
+            return chi
+
+        t = time.time()
+        cmod_stack = np.zeros((len(tims), uH, uW), dtype=np.float64)
+        for i, (tim, (tx0, ty0, th, tw)) in enumerate(zip(tims, img_info)):
+            gy0, gy1 = ty0 - uy0, ty0 + th - uy0
+            gx0, gx1 = tx0 - ux0, tx0 + tw - ux0
+
+            # Local indices relative to the tim's internal buffer (starting at 0,0)
+            # If tx0/ty0 came from a mask, they represent the offset within the tim.
+            ly0, ly1 = ty0, ty0 + th
+            lx0, lx1 = tx0, tx0 + tw
+
+            #print (f'{ux0=} {ux1=} {uy0=} {uy1=} {gy0=} {gy1=} {gx0=} {gx1=} {ly0=} {ly1=} {lx0=} {lx1=}')
+            # Populate the stacks
+            cmodi = self.getModelImage(tim)
+            #print (f'{cmodi.max()=} ', np.where(cmodi == cmodi.max()))
+            cmod_stack[i, gy0:gy1, gx0:gx1] = cmodi[ly0:ly1, lx0:lx1]
+            #print (f'{cmodi.shape=} {cmodi.max()=} {cmod_stack[i].max()=}')
+        cmod_stack = cp.asarray(cmod_stack)
+        tchi[4] += time.time()-t
+
+        #print (f'{cmod_stack.shape=}')
+
+        # 4. Generate the Model stack using the same extent
+        #model_stack = self.getBatchModelImage(use_gpu=use_gpu, batch_psf=batch_psf, modelMasks=modelMasks, tims=tims)
+        #model_stack = self.getBatchModelImage(ux0, uy0, ux1, uy1, use_gpu=use_gpu, batch_psf=batch_psf, tims=tims)
+        #print (f'{model_stack.shape=}')
+        #teng[3] += time.time()-t
+        model_stack = cmod_stack
+
+        tchi[0] += time.time()-tx
+        # 5. Final Chi calculation: (Data - Model) * Weight
+        # Weight is usually Inverse Error (1/sigma)
+        #print (f'{tchi=}')
+        #print (f'{teng=}')
+        #print (f'{tmod=}')
+        #print (f'{tlog=}')
+        return (data_stack - model_stack) * ie_stack
+
+
+
+#    def getBatchChiImages(self, use_gpu=True, batch_psf=None, modelMasks=None, tims=None):
+    def getBatchChiImages_save(self, ux0, uy0, ux1, uy1, use_gpu=True, batch_psf=None, tims=None, ie_stack=None):
+        import cupy as cp
+        import time
+        t = time.time()
+        if tims is None:
+            tims = self.getImages()
+        #if modelMasks is None:
+        #    modelMasks = [self._getModelMaskFor(tim, self.catalog[0]) for tim in tims]
+        
+        # 2. Get the global canvas bounds and the per-image offsets/shapes
+        #(ux0, ux1, uy0, uy1), img_info = get_global_extent(tims, modelMasks)
+        img_info = get_global_extent(tims, ux0, uy0, ux1, uy1)
+        uH, uW = uy1 - uy0, ux1 - ux0
+
+        # 3. Initialize stacks for Data and Inverse Variance
+        data_stack = cp.zeros((len(tims), uH, uW), dtype=cp.float32)
+        #ie_stack = cp.zeros((len(tims), uH, uW), dtype=cp.float32)
+
+        for i, (tim, (tx0, ty0, th, tw)) in enumerate(zip(tims, img_info)):
+            # Global indices relative to the 3D stack origin (ux0, uy0)
+            gy0, gy1 = ty0 - uy0, ty0 + th - uy0
+            gx0, gx1 = tx0 - ux0, tx0 + tw - ux0
+
+            # Local indices relative to the tim's internal buffer (starting at 0,0)
+            # If tx0/ty0 came from a mask, they represent the offset within the tim.
+            ly0, ly1 = ty0, ty0 + th
+            lx0, lx1 = tx0, tx0 + tw
+
+            # Populate the stacks
+            data_stack[i, gy0:gy1, gx0:gx1] = cp.asarray(tim.getImage(use_gpu=True)[ly0:ly1, lx0:lx1])
+            #ie_stack[i, gy0:gy1, gx0:gx1] = cp.asarray(tim.getInvError(use_gpu=True)[ly0:ly1, lx0:lx1])
+            #print (f"Chi Batch {i=} {ie_stack[i].shape=} {ie_stack[i].max()=} {data_stack[i].shape=} {data_stack[i].max()=} {gy0=} {gy1=} {gx0=} {gx1=} {ly0=} {ly1=} {lx0=} {lx1=}")
+
+        teng[2] += time.time()-t
+        t = time.time()
+
+        if ie_stack is None:
+            ie_stack = self.getBatchInvErrors(ux0, uy0, ux1, uy1, use_gpu=use_gpu, tims=tims)
+
+        teng[5] += time.time()-t
+        t = time.time()
+
+        """
+        cdata = np.zeros((len(tims), uH, uW), dtype=np.float32)
+        for i, (tim, (tx0, ty0, th, tw)) in enumerate(zip(tims, img_info)):
+            gy0, gy1 = ty0 - uy0, ty0 + th - uy0
+            gx0, gx1 = tx0 - ux0, tx0 + tw - ux0
+                
+            # Local indices relative to the tim's internal buffer (starting at 0,0)
+            # If tx0/ty0 came from a mask, they represent the offset within the tim.
+            ly0, ly1 = ty0, ty0 + th
+            lx0, lx1 = tx0, tx0 + tw
+                        
+            # Populate the stacks
+            cdata[i, gy0:gy1, gx0:gx1] = tim.getImage()[ly0:ly1, lx0:lx1]
+            #print (f'{i=} {cdata[i].max()=} {data_stack[i].max()=}')
+        cdata = cp.asarray(cdata)
+        teng[1] += time.time()-t
+        t = time.time()
+        """
+
+        cmod_stack = np.zeros((len(tims), uH, uW), dtype=np.float32)
+        for i, (tim, (tx0, ty0, th, tw)) in enumerate(zip(tims, img_info)):
+            gy0, gy1 = ty0 - uy0, ty0 + th - uy0
+            gx0, gx1 = tx0 - ux0, tx0 + tw - ux0
+
+            # Local indices relative to the tim's internal buffer (starting at 0,0)
+            # If tx0/ty0 came from a mask, they represent the offset within the tim.
+            ly0, ly1 = ty0, ty0 + th
+            lx0, lx1 = tx0, tx0 + tw
+
+            #print (f'{ux0=} {ux1=} {uy0=} {uy1=} {gy0=} {gy1=} {gx0=} {gx1=} {ly0=} {ly1=} {lx0=} {lx1=}')
+            # Populate the stacks
+            cmodi = self.getModelImage(tim)
+            #print (f'{cmodi.max()=} ', np.where(cmodi == cmodi.max()))
+            cmod_stack[i, gy0:gy1, gx0:gx1] = cmodi[ly0:ly1, lx0:lx1]
+            #print (f'{cmodi.shape=} {cmodi.max()=} {cmod_stack[i].max()=}')
+        cmod_stack = cp.asarray(cmod_stack)
+
+        teng[0] += time.time()-t
+        t = time.time()
+        """
+        cmod_stack2 = np.zeros((len(tims), uH, uW), dtype=np.float32)
+        for i, (tim, (tx0, ty0, th, tw)) in enumerate(zip(tims, img_info)):
+            gy0, gy1 = ty0 - uy0, ty0 + th - uy0
+            gx0, gx1 = tx0 - ux0, tx0 + tw - ux0
+
+            # Local indices relative to the tim's internal buffer (starting at 0,0)
+            # If tx0/ty0 came from a mask, they represent the offset within the tim.
+            ly0, ly1 = ty0, ty0 + th
+            lx0, lx1 = tx0, tx0 + tw
+
+            #print (f'{ux0=} {ux1=} {uy0=} {uy1=} {gy0=} {gy1=} {gx0=} {gx1=} {ly0=} {ly1=} {lx0=} {lx1=}')
+            # Populate the stacks
+            cmodi = self.getModelSubImageOneSource(tim)
+            #print (f'2 {cmodi.max()=} ', np.where(cmodi == cmodi.max()))
+            if cmodi is None:
+                continue
+            #cmod_stack2[i, gy0:gy1, gx0:gx1] = cmodi
+        cmod_stack2 = cp.asarray(cmod_stack2)
+        """
+
+        #print (f'{cmod_stack.shape=}')
+        #print ("ALLCLOSE", cp.allclose(cmod_stack, cmod_stack2))
+        #teng[6] += time.time()-t
+        t = time.time()
+
+        # 4. Generate the Model stack using the same extent
+        #model_stack = self.getBatchModelImage(use_gpu=use_gpu, batch_psf=batch_psf, modelMasks=modelMasks, tims=tims)
+        #model_stack = self.getBatchModelImage(ux0, uy0, ux1, uy1, use_gpu=use_gpu, batch_psf=batch_psf, tims=tims)
+        #print (f'{model_stack.shape=}')
+        #teng[3] += time.time()-t
+        model_stack = cmod_stack
+
+        # 5. Final Chi calculation: (Data - Model) * Weight
+        # Weight is usually Inverse Error (1/sigma)
+        print (f'{teng=}')
+        return (data_stack - model_stack) * ie_stack

--- a/tractor/engine.py
+++ b/tractor/engine.py
@@ -798,7 +798,7 @@ class Tractor(MultiParams):
             print('psf:', img.getPsf())
         return chi
 
-    def getLogLikelihoodBatch(self, candidate_params, bounds, use_gpu=True, **kwargs):
+    def getLogLikelihoodBatch(self, candidate_params, bounds, use_gpu=True, ie_stack=None, use_less_mem=False, **kwargs):
         """
         candidate_params: List of parameter arrays (one for each alpha)
         Returns: cp.array of shape (len(candidate_params),)
@@ -808,25 +808,64 @@ class Tractor(MultiParams):
         # Expected shape: (N_candidates, N_images, H, W) or (N_candidates, Total_Pixels)
         t = time.time()
         (ux0, ux1, uy0, uy1) = bounds 
-        chi_batch = self.getBatchChiImages(
-            ux0=ux0, uy0=uy0, ux1=ux1, uy1=uy1,
-            candidate_params=candidate_params, 
-            use_gpu=use_gpu, 
-            #batch_psf=self.batch_psf,
-            **kwargs
-        )
-        """
-        print (f'{chi_batch.shape=}')
-        for i in range(chi_batch.shape[0]):
-            print (f'{candidate_params[i]=}')
-            for j in range(chi_batch.shape[1]):
-                print (f'{i=} {j=} {chi_batch[i][j].max()=} {chi_batch[i][j].shape=}') 
-        """
-        
-        # 2. Compute -0.5 * sum(chi^2) across all images/pixels for EACH candidate
-        # We sum across all axes EXCEPT the first one (the candidate index)
-        axes_to_sum = tuple(range(1, chi_batch.ndim))
-        chisq = cp.sum(chi_batch**2, axis=axes_to_sum, dtype=cp.float64)
+
+        if use_less_mem:
+            n_cand = len(candidate_params)
+            # Accumulate on GPU to keep VRAM footprint low
+            total_chisq = cp.zeros(n_cand, dtype=cp.float64)
+            tims = self.images
+            
+            try:
+                for i in range(len(tims)):
+                    self.images = [tims[i]]
+                    
+                    # Slice the specific image's invError from the stack
+                    # We use i:i+1 to maintain the (1, H, W) 3D shape required by the engine
+                    s_ie = None
+                    if ie_stack is not None:
+                        s_ie = ie_stack[i:i+1]
+
+                    # getBatchChiImages sees Nimages=1, keeping FFT workspaces small
+                    chi_i = self.getBatchChiImages(
+                        ux0=ux0, uy0=uy0, ux1=ux1, uy1=uy1,
+                        candidate_params=candidate_params,
+                        use_gpu=use_gpu,
+                        ie_stack=s_ie,
+                        **kwargs
+                    )
+                    
+                    # Sum across (Image, H, W) axes
+                    total_chisq += cp.sum(chi_i**2, axis=(1, 2, 3), dtype=cp.float64)
+                    
+                    # Manual memory management is key for 4k images
+                    del chi_i
+                    cp.get_default_memory_pool().free_all_blocks()
+            finally:
+                self.images = tims
+            chisq = total_chisq
+            tlog[4] += time.time()-t
+            print (f'{tlog=}')
+        else:
+            chi_batch = self.getBatchChiImages(
+                ux0=ux0, uy0=uy0, ux1=ux1, uy1=uy1,
+                candidate_params=candidate_params, 
+                use_gpu=use_gpu, 
+                ie_stack=ie_stack,
+                #batch_psf=self.batch_psf,
+                **kwargs
+            )
+            """
+            print (f'{chi_batch.shape=}')
+            for i in range(chi_batch.shape[0]):
+                print (f'{candidate_params[i]=}')
+                for j in range(chi_batch.shape[1]):
+                    print (f'{i=} {j=} {chi_batch[i][j].max()=} {chi_batch[i][j].shape=}') 
+            """
+            
+            # 2. Compute -0.5 * sum(chi^2) across all images/pixels for EACH candidate
+            # We sum across all axes EXCEPT the first one (the candidate index)
+            axes_to_sum = tuple(range(1, chi_batch.ndim))
+            chisq = cp.sum(chi_batch**2, axis=axes_to_sum, dtype=cp.float64)
         #print ("LOGL", chisq.shape, chi_batch.shape)
         #print (f'{chisq=}')
         tlog[1] += time.time()-t
@@ -864,7 +903,7 @@ class Tractor(MultiParams):
             return -np.inf
         return lnp
 
-    def getLogProbBatch(self, candidate_params, bounds=None, use_gpu=True, ie_stack=None, **kwargs):
+    def getLogProbBatch(self, candidate_params, bounds=None, use_gpu=True, ie_stack=None, use_less_mem=False, **kwargs):
         '''
         Return the posterior log PDF for a batch of candidates.
         Evaluates LogPrior (CPU) + LogLikelihood (GPU).
@@ -892,13 +931,13 @@ class Tractor(MultiParams):
         # Identify candidates that are physically possible
         valid_mask = np.isfinite(priors)
         if not np.any(valid_mask):
-            print ("INVALID")
+            print ("getLogProbBatch> all candidates are INVALID")
             return cp.asarray(priors)
 
         # 2. Evaluate Likelihood for valid candidates only
         # (Optional: You could filter candidate_params here to save GPU time,
         # but for small N like 13, it's often faster to just run the batch)
-        lnl = self.getLogLikelihoodBatch(candidate_params, bounds=bounds, use_gpu=use_gpu, ie_stack=ie_stack, **kwargs)
+        lnl = self.getLogLikelihoodBatch(candidate_params, bounds=bounds, use_gpu=use_gpu, ie_stack=ie_stack, use_less_mem=use_less_mem, **kwargs)
         #print (f'{lnl=}')
         
         # 3. Combine

--- a/tractor/factored_optimizer.py
+++ b/tractor/factored_optimizer.py
@@ -773,89 +773,7 @@ class GPUFriendlyPointSourceFitter:
 
         return H_full, G_full, ni
 
-    
-    def tryUpdates_gpu_old(self, tractor, X, alphas=None, check_step=None):
-        """
-        GPU-accelerated version of the line search.
-        X: The update direction (numpy array)
-        """
-        # 1. Setup initial state
-        p0 = tractor.getParams()
-        logprob_before = tractor.getLogProb()
-        logprob_best = logprob_before
-        alpha_best = None
-        p_best = p0
-
-        # 2. Get the candidate steps (respecting bounds and max_step)
-        # This uses the CPU logic from ConstrainedOptimizer to ensure consistency
-        steps = self.optimizer.getParameterSteps(tractor, X, alphas)
-
-        if len(steps) == 0:
-            self.optimizer.last_step_hit_limit = True
-            self.optimizer.hit_limit = True
-            return 0., 0.
-
-        # 3. Line Search Loop
-        for alpha, p, step_limit, hit_limit in steps:
-            if hit_limit:
-                self.optimizer.hit_limit = True
-
-            # Update the tractor object's state (required for LogPrior and potential callbacks)
-            tractor.setParams(p)
-
-            if check_step is not None:
-                r = check_step(optimizer=self.optimizer, tractor=tractor, X=X, alpha=alpha)
-                if not r:
-                    break
-
-            # --- GPU Likelihood Calculation ---
-            total_chi2 = 0.0
-
-            # We iterate over the images, but the data stays on GPU
-            for i, img in enumerate(tractor.images):
-                # Render the source at the NEW parameters on the GPU
-                # This should return a CuPy array representing the patch
-                model_patch = self.render_source_gpu(img, tractor)
-
-                if model_patch is None:
-                    continue
-
-                # data_gpu and invvar_gpu should be pre-cached CuPy arrays
-                data = self.img_data_gpu[i]
-                invvar = self.img_invvar_gpu[i]
-
-                # Use float64 for the accumulation to prevent precision-driven divergence
-                diff = (data - model_patch)
-                chi2_img = cp.sum((diff**2) * invvar, dtype=cp.float64)
-                total_chi2 += float(chi2_img.get())
-
-            # Combine with Prior (CPU side)
-            log_prior = tractor.getLogPrior()
-            logprob = -0.5 * total_chi2 + log_prior
-
-            # --- Early Exit and Best-Track Logic ---
-            if not np.isfinite(logprob):
-                break
-
-            if logprob < (logprob_best - 1.0):
-                # Significant degradation; stop the line search
-                break
-
-            if logprob > logprob_best:
-                self.optimizer.last_step_hit_limit = hit_limit
-                alpha_best = alpha
-                logprob_best = logprob
-                p_best = p
-
-        # 4. Finalize state
-        tractor.setParams(p_best)
-
-        if alpha_best is None:
-            return 0., 0.
-
-        return logprob_best - logprob_before, alpha_best
-
-    def tryUpdates_gpu(self, X, alphas=None, check_step=None):
+    def tryUpdates_gpu(self, X, alphas=None, check_step=None, use_less_mem=False):
         t_start = time.time()
         (ux0, ux1, uy0, uy1) = self.current_bounds
         if self.ie_batch is None:
@@ -1223,12 +1141,17 @@ class FactoredOptimizer(object):
             xicsum, icsum, _ = img_opts[0]
         else:
             for x,ic in img_opts:
-                #print(f'{x=} {ic=} {tr.catalog[0]=}')
+                print(f'{x=} {ic=} {tr.catalog[0]=}')
                 xicsum = xicsum + np.dot(ic, x)
                 icsum = icsum + ic
         #C = np.linalg.inv(icsum)
         #x = np.dot(C, xicsum)
-        #print (f'{icsum=} {xicsum=}')
+        print (f'{icsum=} {xicsum=}')
+        if np.any(np.isnan(xicsum)):
+            print (f"WARNING: np.dot failed with NAN {xicsum=}.  Running CPU version instead.")
+            x = super().getLinearUpdateDirection(tr, **kwargs) 
+            print ("SUPER x", x)
+            return x 
 
         #Add the priors if needed.
         if orig_priors:
@@ -1253,7 +1176,7 @@ class FactoredOptimizer(object):
         tt[6] += time.time()-t
         #print (f'{tt=}')
         #print (f'{tps=}')
-        #print ("Final X: ",x, "Source", tr.catalog[0])
+        print ("Final X: ",x, "Source", tr.catalog[0])
         #import sys
         #sys.exit(-1)
         if x_imgs is not None:
@@ -1519,6 +1442,11 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
             # Pixel positions
             pxy = [tim.getWcs().positionToPixel(src.getPosition(), src)
                    for tim in tr.images]
+            px, py = np.array(pxy).T
+            if np.any(np.isnan(px)) or np.any(np.isnan(py)):
+                print ("WARNING: px, py contain NANs.  Running CPU version instead.")
+                xout = super().getSingleImageUpdateDirections(tr, **kwargs)
+                return xout
             #New helper method predicts memory needed
             est_mem = self.predict_fft_memory(tr, masks, pxy, nd)
             free_mem /= 1.e+9
@@ -2220,6 +2148,7 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
             return xout
 
         Xic = self.computeUpdateDirectionsVectorized(img_params, priorVals)
+        print (f"{Xic=}")
 
         mpool = cp.get_default_memory_pool()
         del img_params
@@ -2244,6 +2173,7 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
             (X, Xicov) = Xic
             X = X.get()
             Xicov = Xicov.get()
+            print (f"{fullN=} {npos=} {nbands=}")
             for iband,x,ic in zip(img_bands, X, Xicov):
                 #assert(fullN == len(x) + nbands - 1)
                 # the "x" here are from fitting on a single image, *assuming* 2 positions are being fit
@@ -2327,6 +2257,7 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
         #
         #print('Calling original version...')
         #sXic = super().getSingleImageUpdateDirections(tr, **kwargs)
+        print (f"Final {Xic=}")
         return Xic
 
     def computeUpdateDirections(self, img_params, priorVals):
@@ -3175,7 +3106,7 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
         # first two columns of A are all zero, the ATA ATB method fails with
         # NaNs.  But we can strip out those rows and zero-pad the output!
         if not np.any(fit_pos):
-            #print ("WARNING: fit_pos is False for all images, stripping off rows to prevent NaNs before fitting")
+            print ("WARNING: fit_pos is False for all images, stripping off rows to prevent NaNs before fitting")
             A_T_dot_A = cp.einsum("...ji,...jk", A[:,:,2:], A[:,:,2:])
             A_T_dot_B = cp.einsum("...ji,...j", A[:,:,2:], B)
             X = cp.zeros((Nimages, Nd+2), dtype=cp.float32)
@@ -3183,14 +3114,20 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
         else:
             A_T_dot_A = cp.einsum("...ji,...jk", A, A)
             A_T_dot_B = cp.einsum("...ji,...j", A, B)
+            print (f"{A_T_dot_A=} {A_T_dot_B=}")
             X = cp.linalg.solve(A_T_dot_A, A_T_dot_B)
 
+        print (f"GPU {X=} {A.sum(axis=1)=} {B.sum()=}")
+        print (f"{X.shape=} {A.shape=} {B.shape=}")
         # Undo pre-scaling
         ###  TAG: ISSUE 1 4/9/25 - uncomment and move divide within block to get rid of NaNs 
         #if fit_pos[0] is True:
         X /= colscales
         #print ("NANs", cp.isnan(X).sum())
+        #if cp.any(cp.isinf(X)):
+        #    print ("NAN", X)
         X[cp.isnan(X)] = 0
+        #X[cp.isinf(X)] = 0
         #print ("X NORM", X.shape)
         #    print ("X norm", X)
         #else:
@@ -3264,7 +3201,11 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
 
         # 2. Calculate the Power-of-Two padding
         radius_max = gpu_halfsize.max()
-        sz = 2**int(np.ceil(np.log2(radius_max * 2.)))
+        try:
+            sz = 2**int(np.ceil(np.log2(radius_max * 2.)))
+        except Exception as ex:
+            print (f'predict_fft_memory> {gpu_halfsize=} {radius_max=} {x0=} {x1=} {y0=} {y1=} {px=} {py=} '+str(ex))
+            return 1.e+12
 
         pH, pW = sz, sz
         n_images = len(tr.images)
@@ -3471,6 +3412,8 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
         # 1. Fallback if GPU is disabled
         if self._gpumode == 0 or self._gpumode == 4:
             return super().tryUpdates(tractor, X, alphas=alphas, check_step=check_step)
+        import cupy as cp
+        import datetime
         #return super().tryUpdates(tractor, X, alphas=alphas)
         #lp1 = super().tryUpdates(tractor, X, alphas=alphas)
         #print (f'{lp1=}')
@@ -3502,46 +3445,91 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
                     #tractor.setParams(p0)
 
 
-                    """
                     #Estimate memory needed with new helper method based on padded image sizes and nd
-                    import cupy as cp
-                    import datetime
-                    # pixel position of the source in each image
-                    xy = [tim.getWcs().positionToPixel(src.pos) for tim in tractor.images]
-                    # pixel region to render
-                    masks = [tractor._getModelMaskFor(tim, src) for tim in tractor.images]
+                    src = tractor.catalog[0]
 
+                    # 1. Get masks and find which images actually overlap
+                    all_tims = tractor.images
+                    all_masks = tractor.modelMasks
+
+                    # Filter out the "None" masks
+                    # Store the original full list of dicts to restore later
+                    all_mask_dicts = tractor.modelMasks 
+                    
+                    valid_tims = []
+                    valid_mask_objects = []
+                    valid_mask_dicts = []
+
+                    for tim in all_tims:
+                        m = tractor._getModelMaskFor(tim, src)
+                        if m is not None:
+                            valid_tims.append(tim)
+                            valid_mask_objects.append(m)
+                            # Re-wrap the mask in a dict so tractor can still query it by source
+                            valid_mask_dicts.append({src: m})
+
+                    if len(valid_tims) == 0:
+                        print("Source has no overlap with any image; log-likelihood is 0.")
+                        # Handle edge case: no overlap at all
+                        return 0.0, 0.0 
+
+                    # 2. Update context with the expected data structures
+                    tractor.images = valid_tims
+                    # This is now a list of dicts, keeping tractor happy
+                    tractor.modelMasks = valid_mask_dicts
+                    if len(valid_tims) != len(all_tims):
+                        print (f'TryUpdates PS: Warning {len(valid_tims)=} {len(all_tims)=} - ONE OR MORE model masks are None.')
+                    Nimages = len(valid_tims) # The new, filtered count
                     #Get free memory
                     mempool = cp.get_default_memory_pool()
                     mempool.free_all_blocks()
                     free_mem, total_mem = cp.cuda.runtime.memGetInfo()
                     nd = tractor.numberOfParams()+2
-                    assert(all([m is not None for m in masks]))
-                    #New helper method predicts memory needed
-                    est_mem = self.predict_fft_memory(tractor, masks, xy, nd)
-                    free_mem /= 1.e+9
-                    print (f'TryUpdates PS: Estimated memory {est_mem} GB free memory {free_mem} for {Nimages=} {nd=} at ', datetime.datetime.now(), "src = ", tractor.catalog[0])
-                    use_less_mem = False
-                    if free_mem < est_mem:
-                        print(f"Warning: TryUpdates PS Estimated memory {est_mem} GB is greater than free memory {free_mem} GB; Running less-mem GPU mode instead!", datetime.datetime.now(), "src = ", tractor.catalog[0])
-                        #s_d, s_a = super().tryUpdates(tractor, X, alphas=alphas, check_step=check_step)
-                        #tu[5] += time.time()-t
-                        #return s_d, s_a
-                        use_less_mem = True
-                    """
 
-                    t = time.time()
                     try:
-                        best_dlnp, best_alpha = self.current_fitter.tryUpdates_gpu(X, alphas, check_step=check_step)
+                        # Estimate memory using ONLY the images we will actually render
+                        # pixel position of the source in each image
+                        xy_valid = [tim.getWcs().positionToPixel(src.pos) for tim in valid_tims]
+                        px, py = np.array(xy_valid).T
+                        if np.any(np.isnan(px)):
+                            xy2 = [tim.getWcs().positionToPixel(src.pos) for tim in all_tims]
+                            px2, py2 = np.array(xy2).T
+                            print (f'NAN PS {px=} {py=} {px2=} {py2=}')
+
+                        est_mem = self.predict_fft_memory(tractor, valid_mask_objects, xy_valid, nd)
+                        free_mem /= 1.e+9
+                        print (f'TryUpdates PS: Estimated memory {est_mem} GB free memory {free_mem} for {Nimages=} {nd=} at ', datetime.datetime.now(), "src = ", tractor.catalog[0])
+                        use_less_mem = False
+                        if free_mem < est_mem:
+                            print(f"Warning: TryUpdates PS Estimated memory {est_mem} GB is greater than free memory {free_mem} GB; Running less-mem GPU mode instead!", datetime.datetime.now(), "src = ", tractor.catalog[0])
+                            use_less_mem = True
+
+                        t = time.time()
+                        self.current_fitter.ie_batch = None
+                        best_dlnp, best_alpha = self.current_fitter.tryUpdates_gpu(X, alphas, check_step=check_step, use_less_mem=use_less_mem)
                         tu[0] += time.time()-t
                     except Exception as ex:
-                        print ("Exception in TRY UPDATES GPU - running CPU version instead: "+str(ex))
+                        print ("Exception in TRY UPDATES PS GPU - running CPU version instead: "+str(ex))
+                        import sys
+                        sys.stderr.write(f"\n----Traceback below----\n")
+                        import traceback 
+                        traceback.print_exc()
+                        sys.stderr.flush()
+                        sys.exit(-1)
                         tu[0] += time.time()-t
                         t = time.time()
+                        tractor.images = all_tims
+                        tractor.modelMasks = all_masks
                         tractor.setParams(p0)
                         s_d, s_a = super().tryUpdates(tractor, X, alphas=alphas, check_step=check_step)
                         tu[1] += time.time()-t
                         return s_d, s_a
+                    finally:
+                        # CRITICAL: Restore the original image list so Tractor doesn't
+                        # "forget" the other images for the rest of the brick
+                        tractor.images = all_tims
+                        tractor.modelMasks = all_masks
+
                     #import sys
                     #sys.exit(0)
                     # Clean up after the line search is done
@@ -3613,189 +3601,220 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
         # steps: list of (alpha, params, step_lim, param_lim)
         steps.append((0., p0, False, False))
 
-        # pixel position of the source in each image
-        xy = [tim.getWcs().positionToPixel(src.pos) for tim in tractor.images]
-        px, py = np.array(xy).T
-        # pixel region to render
-        masks = [tractor._getModelMaskFor(tim, src) for tim in tractor.images]
-        if any(m is None for m in masks):
-            print (f"TryUpdates WARNING: One or more modelMasks is None; running CPU version.")
-            s_d, s_a = super().tryUpdates(tractor, X, alphas=alphas, check_step=check_step)
-            tu[5] += time.time()-t
-            return s_d, s_a
+        # Filter out the "None" masks
+        # Store the original full list of dicts to restore later
+        all_tims = tractor.images
+        all_masks = tractor.modelMasks
+        
+        valid_tims = [] 
+        valid_mask_objects = []
+        valid_mask_dicts = []
 
-        #Estimate memory needed with new helper method based on padded image sizes and nd
-        import cupy as cp
-        import datetime
-        #Get free memory
-        mempool = cp.get_default_memory_pool()
-        mempool.free_all_blocks()
-        free_mem, total_mem = cp.cuda.runtime.memGetInfo()
-        nd = tractor.numberOfParams()+2
-        assert(all([m is not None for m in masks]))
-        #New helper method predicts memory needed
-        est_mem = self.predict_fft_memory(tractor, masks, xy, nd)
-        free_mem /= 1.e+9
-        print (f'TryUpdates: Estimated memory {est_mem} GB free memory {free_mem} for {Nimages=} {nd=} at ', datetime.datetime.now(), "src = ", tractor.catalog[0])
-        use_less_mem = False
-        if free_mem < est_mem:
-            print(f"Warning: TryUpdates Estimated memory {est_mem} GB is greater than free memory {free_mem} GB; Running less-mem GPU mode instead!", datetime.datetime.now(), "src = ", tractor.catalog[0])
-            #s_d, s_a = super().tryUpdates(tractor, X, alphas=alphas, check_step=check_step)
-            #tu[5] += time.time()-t
-            #return s_d, s_a
-            use_less_mem = True
+        for tim in all_tims:
+            m = tractor._getModelMaskFor(tim, src)
+            if m is not None:
+                valid_tims.append(tim)
+                valid_mask_objects.append(m)
+                # Re-wrap the mask in a dict so tractor can still query it by source
+                valid_mask_dicts.append({src: m})
 
-        img_sky = [tim.getSky().getConstant() for tim in tractor.images]
-        img_pix = [tim.getImage(use_gpu=True) for tim in tractor.images]
-        img_ie  = [tim.getInvError(use_gpu=True) for tim in tractor.images]
-        #print ("MAXES", img_pix[0].max(), img_ie[0].max())
-        #print ("SUMS", img_pix[0].sum(), img_ie[0].sum())
+        if len(valid_tims) == 0:
+            print("Source has no overlap with any image; log-likelihood is 0.")
+            # Handle edge case: no overlap at all
+            return 0.0, 0.0
 
-        profiles = []
-        fluxes = []
-        logpriors = []
-        for _,p,_,_ in steps:
-            #print ("P", p)
-            tractor.setParams(p)
-            # for _getBatchGalaxyProfiles we need tuples of (name, amix, step)...
-            profiles.append(('', getShearedProfileGPU(src, tractor.images, px, py), 0.))
-            # grab the brightnesses
-            fluxes.append([tim.getPhotoCal().brightnessToCounts(src.brightness) for tim in tractor.images])
-            # While we're stepping through the parameters, compute log-priors...
-            lp = tractor.getLogPrior()
-            logpriors.append(lp)
-        # Unfortunately, Sersic galaxies can get a different number of Gaussian mixture components
-        # as we step the Sersic index parameter, so in the "profiles" above, they can have different
-        # sizes; _getBatchGalaxyProfiles requires them to be the same sizes - so check and pad if
-        # necessary.
-        ng = np.unique([pro.var.shape[1] for _,pro,_ in profiles])
-        if len(ng) != 1:
-            # pad
-            padsize = max(ng)
-            for _,pro,_ in profiles:
-                shape = pro.var.shape
-                # needs padding?
-                oldsize = shape[1]
-                if shape[1] == padsize:
-                    continue
-                newshape = (shape[0], padsize, shape[2], shape[3])
-                # var: size (nimages, ng, 2, 2) - cupy
-                padded = cp.zeros(newshape)
-                padded[:,:oldsize,:,:] = pro.var
-                pro.var = padded
-                # amp: size (ng,) -- a numpy array (not cupy) for some reason
-                padded = np.zeros(padsize)
-                padded[:oldsize] = pro.amp
-                pro.amp = padded
-                # mean: size (ng,2) -- also a numpy array
-                shape = pro.mean.shape
-                newshape = (padsize, shape[1])
-                padded = np.zeros(newshape)
-                padded[:oldsize,:] = pro.mean
-                pro.mean = padded
+        # 2. Update context with the expected data structures
+        tractor.images = valid_tims
+        # This is now a list of dicts, keeping tractor happy
+        tractor.modelMasks = valid_mask_dicts
 
-        if use_less_mem:
-            # Initialize the accumulator for all alpha steps
-            # This stays on the GPU so we don't transfer back and forth in the loop
-            total_chisq = cp.zeros(len(steps), dtype=cp.float32)
-            
-            # Pre-convert fluxes to GPU once (it's a small array)
-            # Shape: (nsteps, Nimages)
-            fluxes_gpu = cp.asarray(fluxes, dtype=cp.float32)
+        if len(valid_tims) != len(all_tims):
+            print (f'TryUpdates Gal: Warning {len(valid_tims)=} {len(all_tims)=} - ONE OR MORE model masks are None.')
+        Nimages = len(valid_tims)
+        nd = tractor.numberOfParams() + 2
 
-            tims = tractor.images
-            modelmasks = tractor.modelMasks
+        try:
+            # Position in valid images only
+            xy = [tim.getWcs().positionToPixel(src.pos) for tim in valid_tims]
+            px, py = np.array(xy).T
+            if np.any(np.isnan(px)):
+                xy2 = [tim.getWcs().positionToPixel(src.pos) for tim in all_tims]
+                px2, py2 = np.array(xy2).T
+                print (f'NAN {px=} {py=} {px2=} {py2=}')
 
-            try:
-                for i in range(Nimages):
-                    # 1. Extract single-image data
-                    # We wrap these in lists so your existing Batch methods still work
-                    s_masks = [masks[i]]
-                    s_xy = [xy[i]]
-                    s_sky = [img_sky[i]]
-                    s_pix = [img_pix[i]]
-                    s_ie = [img_ie[i]]
-                    
+            #Get free memory
+            mempool = cp.get_default_memory_pool()
+            mempool.free_all_blocks()
+            free_mem, total_mem = cp.cuda.runtime.memGetInfo()
+            #New helper method predicts memory needed
+            est_mem = self.predict_fft_memory(tractor, valid_mask_objects, xy, nd)
+            free_mem /= 1.e+9
+            print (f'TryUpdates: Estimated memory {est_mem} GB free memory {free_mem} for {Nimages=} {nd=} at ', datetime.datetime.now(), "src = ", tractor.catalog[0])
+            use_less_mem = False
+            if free_mem < est_mem:
+                print(f"Warning: TryUpdates Estimated memory {est_mem} GB is greater than free memory {free_mem} GB; Running less-mem GPU mode instead!", datetime.datetime.now(), "src = ", tractor.catalog[0])
+                use_less_mem = True
+            img_sky = [tim.getSky().getConstant() for tim in tractor.images]
+            img_pix = [tim.getImage(use_gpu=True) for tim in tractor.images]
+            img_ie  = [tim.getInvError(use_gpu=True) for tim in tractor.images]
+            profiles = []
+            fluxes = []
+            logpriors = []
+            for _,p,_,_ in steps:
+                #print ("P", p)
+                tractor.setParams(p)
+                # for _getBatchGalaxyProfiles we need tuples of (name, amix, step)...
+                profiles.append(('', getShearedProfileGPU(src, tractor.images, px, py), 0.))
+                # grab the brightnesses
+                fluxes.append([tim.getPhotoCal().brightnessToCounts(src.brightness) for tim in tractor.images])
+                # While we're stepping through the parameters, compute log-priors...
+                lp = tractor.getLogPrior()
+                logpriors.append(lp)
 
-                    # 1. Create single-image profile data
-                    s_profiles = []
-                    for name, amix, step in profiles:
-                        #print (f'{amix.mean.shape=} {amix.amp.shape=} {amix.var.shape=}')
-                        #print (f'{type(amix)=}')
-                        #s_mean = amix.mean[i:i+1] # (1, Nd, K, D)
-                        #s_amp  = amix.amp[i:i+1]  # (1, Nd, K)
-                        s_var  = amix.var[i:i+1]  # (1, Nd, K, D, D)
-                        # amix.amp and amix.mean are usually shared (ng, ...) 
-                        # but if they were per-image, you'd slice them here too.
-                        #s_amix = BatchMixtureOfGaussians(s_amp, s_mean, s_var)
-                        s_amix = BatchMixtureOfGaussians(amix.amp, amix.mean, s_var, unbalanced=True)
-                        s_profiles.append((name, s_amix, step))
+            # Unfortunately, Sersic galaxies can get a different number of Gaussian mixture components
+            # as we step the Sersic index parameter, so in the "profiles" above, they can have different
+            # sizes; _getBatchGalaxyProfiles requires them to be the same sizes - so check and pad if
+            # necessary.
+            ng = np.unique([pro.var.shape[1] for _,pro,_ in profiles])
+            if len(ng) != 1:
+                # pad
+                padsize = max(ng)
+                for _,pro,_ in profiles:
+                    shape = pro.var.shape
+                    # needs padding?
+                    oldsize = shape[1]
+                    if shape[1] == padsize:
+                        continue
+                    newshape = (shape[0], padsize, shape[2], shape[3])
+                    # var: size (nimages, ng, 2, 2) - cupy
+                    padded = cp.zeros(newshape)
+                    padded[:,:oldsize,:,:] = pro.var
+                    pro.var = padded
+                    # amp: size (ng,) -- a numpy array (not cupy) for some reason
+                    padded = np.zeros(padsize)
+                    padded[:oldsize] = pro.amp
+                    pro.amp = padded
+                    # mean: size (ng,2) -- also a numpy array
+                    shape = pro.mean.shape
+                    newshape = (padsize, shape[1])
+                    padded = np.zeros(newshape)
+                    padded[:oldsize,:] = pro.mean
+                    pro.mean = padded
 
-                    tractor.images = [tims[i]]
-                    tractor.modelMasks = [modelmasks[i]]
-                    # 2. Setup single-image parameters and profiles
-                    # This keeps pH/pW consistent with the single image's needs
-                    img_params_i, cx_i, cy_i, pW_i, pH_i = self._getBatchImageParams(tractor, s_masks, s_xy)
-                    
-                    # Slicing fluxes_gpu for just this image: fluxes_gpu[:, i]
-                    gals_i = self._getBatchGalaxyProfiles(s_profiles, s_masks, px[i:i+1], py[i:i+1], 
-                                                          cx_i, cy_i, pW_i, pH_i,
-                                                          fluxes_gpu[0, i:i+1], s_sky, s_pix, s_ie)
-                    
-                    img_params_i.addBatchGalaxyProfiles(gals_i)
-                    
-                    # 3. Render and Calculate Chi2 for this image
-                    # G_i shape: (1, nsteps, pH_i, pW_i)
-                    G_i = self.computeGalaxyModelsVectorized(img_params_i)
-                    
-                    # Call a modified version of your chi2 function or inline it:
-                    # We sum over the image axes (2 and 3) and the single image axis (0)
-                    # to get a (nsteps,) result to add to total_chisq.
-                    total_chisq += self.calculate_chi2_cupy(G_i, fluxes_gpu[:, [i]], 
-                                                            gals_i.mmpix, gals_i.mmie, 
-                                                            cp.asarray(s_sky))
+            if use_less_mem:
+                # Initialize the accumulator for all alpha steps
+                # This stays on the GPU so we don't transfer back and forth in the loop
+                total_chisq = cp.zeros(len(steps), dtype=cp.float32)
 
-                    # 4. CRITICAL: Clear the deck for the next image
-                    del G_i, img_params_i, gals_i, s_pix, s_ie
-                    cp.get_default_memory_pool().free_all_blocks()
+                # Pre-convert fluxes to GPU once (it's a small array)
+                # Shape: (nsteps, Nimages)
+                fluxes_gpu = cp.asarray(fluxes, dtype=cp.float32)
 
-            finally:
-                # Always restore state even if the loop fails
-                tractor.images = tims
-                tractor.modelMasks = modelmasks
-            # Move final result back to CPU for the logprob logic
-            chisq = total_chisq
-        else:
-            img_params, cx,cy,pW,pH = self._getBatchImageParams(tractor, masks, xy)
+                tims = tractor.images
+                modelmasks = valid_mask_objects 
 
-            gals = self._getBatchGalaxyProfiles(profiles, masks, px, py, cx, cy, pW, pH,
-                                                fluxes[0], img_sky, img_pix, img_ie)
-            img_params.addBatchGalaxyProfiles(gals)
-            if img_params.ffts is None:
-                print ("Warning> img_params.ffts is None!  Calling superclass tryUpdates (on CPU)")
-                #print (f'TU Z2 0 {s_d=} 0 {s_a=}')
-                tu[6] += time.time()-t
-                return super().tryUpdates(tractor, X, alphas=alphas, check_step=check_step)
-            G = self.computeGalaxyModelsVectorized(img_params)
-            assert(G.shape == (Nimages, len(steps), pH, pW))
-            mmpix = gals.mmpix
-            mmie = gals.mmie
-            fluxes = cp.asarray(fluxes, dtype=cp.float32)
-            sky = cp.asarray(img_sky, dtype=cp.float32)
-            #print ("MMPIX", mmpix.shape, mmie.shape, mmpix.max(), mmpix.sum())
-            #print ("FLUXES", fluxes.shape, fluxes)
-            #print ("SKY", sky.shape, sky)
+                try:
+                    for i in range(Nimages):
+                        # 1. Extract single-image data
+                        # We wrap these in lists so your existing Batch methods still work
+                        s_masks = [modelmasks[i]]
+                        s_xy = [xy[i]]
+                        s_sky = [img_sky[i]]
+                        s_pix = [img_pix[i]]
+                        s_ie = [img_ie[i]]
 
-            #print ("G", G.shape)
-            #chisq = cp.sum([((G[i_image] * fluxes[i_step, i_image] - mmpix[i_image]) * mmie[i_image])**2 for i_image in range(Nimages)])
-            chisq = self.calculate_chi2_cupy(G, fluxes, mmpix, mmie, sky) 
-            del G, img_params
-            mpool = cp.get_default_memory_pool()
-            mpool.free_all_blocks()
-            #print ("CHISQ", chisq.shape)
 
-        #print ("PRIOR", logpriors)
-        logprob = np.array(logpriors)-0.5*chisq.get()
+                        # 1. Create single-image profile data
+                        s_profiles = []
+                        for name, amix, step in profiles:
+                            #print (f'{amix.mean.shape=} {amix.amp.shape=} {amix.var.shape=}')
+                            #print (f'{type(amix)=}')
+                            #s_mean = amix.mean[i:i+1] # (1, Nd, K, D)
+                            #s_amp  = amix.amp[i:i+1]  # (1, Nd, K)
+                            s_var  = amix.var[i:i+1]  # (1, Nd, K, D, D)
+                            # amix.amp and amix.mean are usually shared (ng, ...) 
+                            # but if they were per-image, you'd slice them here too.
+                            #s_amix = BatchMixtureOfGaussians(s_amp, s_mean, s_var)
+                            s_amix = BatchMixtureOfGaussians(amix.amp, amix.mean, s_var, unbalanced=True)
+                            s_profiles.append((name, s_amix, step))
+
+                        tractor.images = [tims[i]]
+                        tractor.modelMasks = [valid_mask_dicts[i]]
+                        # 2. Setup single-image parameters and profiles
+                        # This keeps pH/pW consistent with the single image's needs
+                        img_params_i, cx_i, cy_i, pW_i, pH_i = self._getBatchImageParams(tractor, s_masks, s_xy)
+
+                        # Slicing fluxes_gpu for just this image: fluxes_gpu[:, i]
+                        gals_i = self._getBatchGalaxyProfiles(s_profiles, s_masks, px[i:i+1], py[i:i+1],
+                                                              cx_i, cy_i, pW_i, pH_i,
+                                                              fluxes_gpu[0, i:i+1], s_sky, s_pix, s_ie)
+
+                        img_params_i.addBatchGalaxyProfiles(gals_i)
+
+                        # 3. Render and Calculate Chi2 for this image
+                        # G_i shape: (1, nsteps, pH_i, pW_i)
+                        G_i = self.computeGalaxyModelsVectorized(img_params_i)
+
+                        # Call a modified version of your chi2 function or inline it:
+                        # We sum over the image axes (2 and 3) and the single image axis (0)
+                        # to get a (nsteps,) result to add to total_chisq.
+                        total_chisq += self.calculate_chi2_cupy(G_i, fluxes_gpu[:, [i]],
+                                                                gals_i.mmpix, gals_i.mmie,
+                                                                cp.asarray(s_sky))
+
+                        # 4. CRITICAL: Clear the deck for the next image
+                        del G_i, img_params_i, gals_i, s_pix, s_ie, s_amix, s_var
+                        cp.get_default_memory_pool().free_all_blocks()
+
+                finally:
+                    # Always restore state even if the loop fails
+                    tractor.images = tims
+                    tractor.modelMasks = modelmasks
+                # Move final result back to CPU for the logprob logic
+                chisq = total_chisq
+            else:
+                img_params, cx,cy,pW,pH = self._getBatchImageParams(tractor, valid_mask_objects, xy)
+                gals = self._getBatchGalaxyProfiles(profiles, valid_mask_objects, px, py, cx, cy, pW, pH,
+                                                    fluxes[0], img_sky, img_pix, img_ie)
+                img_params.addBatchGalaxyProfiles(gals)
+                if img_params.ffts is None:
+                    print ("Warning> img_params.ffts is None!  Calling superclass tryUpdates (on CPU)")
+                    #print (f'TU Z2 0 {s_d=} 0 {s_a=}')
+                    tu[6] += time.time()-t
+                    return super().tryUpdates(tractor, X, alphas=alphas, check_step=check_step)
+                G = self.computeGalaxyModelsVectorized(img_params)
+                assert(G.shape == (Nimages, len(steps), pH, pW))
+                mmpix = gals.mmpix
+                mmie = gals.mmie
+                fluxes = cp.asarray(fluxes, dtype=cp.float32)
+                sky = cp.asarray(img_sky, dtype=cp.float32)
+                #print ("MMPIX", mmpix.shape, mmie.shape, mmpix.max(), mmpix.sum())
+                #print ("FLUXES", fluxes.shape, fluxes)
+                #print ("SKY", sky.shape, sky)
+
+                #print ("G", G.shape)
+                #chisq = cp.sum([((G[i_image] * fluxes[i_step, i_image] - mmpix[i_image]) * mmie[i_image])**2 for i_image in range(Nimages)])
+                chisq = self.calculate_chi2_cupy(G, fluxes, mmpix, mmie, sky)
+                del G, img_params
+                mpool = cp.get_default_memory_pool()
+                mpool.free_all_blocks()
+                #print ("CHISQ", chisq.shape)
+
+            #print ("PRIOR", logpriors)
+            logprob = np.array(logpriors)-0.5*chisq.get()
+        except Exception as ex:
+            print(f"Exception in Galaxy TRY UPDATES GPU: {ex}. Falling back to CPU.")
+            tractor.setParams(p0)
+            # Restore full image list for CPU fallback
+            tractor.images = all_tims
+            tractor.modelMasks = all_masks
+            return super().tryUpdates(tractor, X, alphas=alphas, check_step=check_step)
+
+        finally:
+            # CRITICAL: Restore the full list
+            tractor.images = all_tims
+            tractor.modelMasks = all_masks
+
         #print ("LOGPROB", logprob.shape)
 
         # CRAIG -- at this point, we have rendered the galaxy models, in G.
@@ -3836,7 +3855,7 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
         for i in range(len(steps)):
             if steps[i][2]:
                 self.hit_limit = True #set if any hits limit
-        
+
         tt[6] += time.time()-t
         if max_idx == len(logprob)-1:
             print ("Best is previous")
@@ -3856,7 +3875,6 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
         #if s_a != alpha:
         #    print ("GAL MISMATCH")
         return (lp_best-lp_last, alpha)
-
 
     def calculate_chi2_cupy(self, G, fluxes, mmpix, mmie, sky):
         """

--- a/tractor/factored_optimizer.py
+++ b/tractor/factored_optimizer.py
@@ -1,6 +1,6 @@
 import sys
 from tractor.dense_optimizer import ConstrainedDenseOptimizer
-from tractor import ProfileGalaxy, HybridPSF
+from tractor import ProfileGalaxy, HybridPSF, PointSource
 from tractor import mixture_profiles as mp
 from tractor.psf import lanczos_shift_image
 from tractor.sky import ConstantSky
@@ -16,14 +16,1031 @@ from tractor.patch import ModelMask
 import cupy as cp
 import time
 import os, gc
+from tractor.miscutils import get_splat_kernel, get_mog_eval_kernel
+from tractor.brightness import NanoMaggies
 
 tt = np.zeros(8)
 tct = np.zeros(9, np.int32)
 tt2 = np.zeros(1, np.int32)
+tps = np.zeros(20)
+cps = np.zeros(10)
+gps = np.zeros(10)
+tu = np.zeros(10)
+tuc = np.zeros(5, np.int32)
+t5 = np.zeros(2)
 
 image_counter = 0
 #from astrometry.util.plotutils import PlotSequence
 #ps = PlotSequence('fourier')
+
+class GPUFriendlyPointSourceFitter:
+    def __init__(self, tractor, source, images):
+        self.tractor = tractor
+        self.source = source
+        self.images = images
+        self.cpucomp = None
+        self.batch_psf = None
+        self.tiny_alpha = 1e-8
+        self.stepLimited = False
+        self.current_bounds = None
+        self.ie_batch = None
+
+    def add_comp(self, R_cpu):
+        self.cpucomp = R_cpu
+
+    def get_batch_psf(self):
+        psfs = [tim.getPsf() for tim in self.images]
+        #for i, psf in enumerate(psfs):
+        #    print ("Get Batch psf: ", i, psf.img.shape, psf.img.max())
+        self.batch_psf = BatchPixelizedPSF(psfs, True)
+
+    def compute_update_vec(self, allderivs):
+        """
+        Calculates the total Hessian (H) and Gradient (G) for the given derivatives
+        across all images. Returns (H, G) as CuPy arrays.
+        
+        allderivs: list of lists [ (param0) [ (patch, img), ... ], (param1) [...] ]
+        """
+        t = time.time()
+        num_params = len(allderivs)
+        #print (f'{allderivs=}')
+        #print (f'GPU {num_params=}')
+        if num_params == 0:
+            return None, None, 0
+
+        # 1. Pivot: Group patches by Image to minimize GPU overhead
+        # Structure: img -> {global_param_idx: PatchObject}
+        img_map = {}
+        for p_idx, patches in enumerate(allderivs):
+            for patch, img in patches:
+                if patch is None or patch.patch is None:
+                    print (f'{p_idx=} patch is none')
+                    continue
+                if img not in img_map:
+                    img_map[img] = {}
+                img_map[img][p_idx] = patch
+
+        # 2. CREATE THE ORDERED LIST OF ACTIVE IMAGES
+        # This ensures the i-th slice of our batch matches the i-th image in our loop
+        #psfs = []
+        #active_tims = []
+        #for i, (img, params) in enumerate(img_map.items()):
+        #    active_tims.append(img)
+        #    psfs.append(img.getPsf())
+        active_tims = list(img_map.keys())
+
+        ##2b update batch_psf
+        """
+        psfs = [tim.getPsf() for tim in active_tims]
+        self.batch_psf = BatchPixelizedPSF(psfs, True)
+        """
+
+        """
+        # 3. Determine the Global Super-Box across ALL images
+        all_x0, all_x1, all_y0, all_y1 = [], [], [], []
+        for patches in allderivs:
+            for patch, _ in patches:
+                if patch:
+                    all_x0.append(patch.extent[0])
+                    all_x1.append(patch.extent[1])
+                    all_y0.append(patch.extent[2])
+                    all_y1.append(patch.extent[3])
+
+        if len(all_x0) == 0:
+            return None, None, 0
+        ux0, ux1 = min(all_x0), max(all_x1)
+        uy0, uy1 = min(all_y0), max(all_y1)
+        """
+
+        # 3. Calculate the 'true' global union from patch extents
+        # This replaces the logic that relies on the (sometimes too tight) modelMasks
+        all_x0, all_x1, all_y0, all_y1 = [], [], [], []
+        for img, params in img_map.items():
+            for p_idx, patch in params.items():
+                px0, px1, py0, py1 = patch.extent
+                all_x0.append(px0); all_x1.append(px1)
+                all_y0.append(py0); all_y1.append(py1)
+
+        if len(all_x0) == 0:
+            return None, None, 0
+        ux0, ux1 = min(all_x0), max(all_x1)
+        uy0, uy1 = min(all_y0), max(all_y1)
+        ux0 = int(ux0)
+        uy0 = int(uy0)
+        ux1 = int(ux1)
+        uy1 = int(uy1)
+        #uH, uW = uy1 - uy0, ux1 - ux0
+        u_height, u_width = uy1 - uy0, ux1 - ux0
+        total_pixels = u_height * u_width
+        num_imgs = len(img_map)
+        num_params = len(allderivs)
+
+        # 4. Pre-allocate Tensors on GPU
+        # J: (N_images, N_params, Total_Pixels)
+        # Chi: (N_images, Total_Pixels)
+        #J_tensor = cp.zeros((num_imgs, num_params, total_pixels), dtype=cp.float64)
+        J_tensor = cp.zeros((num_imgs, num_params, u_height, u_width), dtype=cp.float64)
+        J_tensor2 = cp.zeros((num_imgs, num_params, u_height, u_width), dtype=cp.float64)
+        #cJ_tensor = np.zeros((num_imgs, num_params, total_pixels), dtype=np.float64)
+        cJ_tensor = np.zeros((num_imgs, num_params, u_height, u_width), dtype=np.float32)
+        Chi_tensor = cp.zeros((num_imgs, total_pixels), dtype=cp.float64)
+        #print ("ChiT", Chi_tensor.shape)
+        print (f'{ux0=} {ux1=} {uy0=} {uy1=}')
+        #print (f'{all_x0=} {all_x1=} {all_y0=} {all_y1=}')
+        print (f'{num_imgs=} {num_params=} {total_pixels=} {u_width=} {u_height=}')
+        tps[2] += time.time()-t
+
+        t = time.time()
+
+        masks = [self.tractor._getModelMaskFor(tim, self.source) for tim in active_tims]
+        #masks = [self.tractor._getModelMaskByIdx(i, self.source) for i in range(len(self.images))]
+        t1 = time.time()
+        ie_batch = self.tractor.getBatchInvErrors(ux0=ux0, ux1=ux1, uy0=uy0, uy1=uy1, use_gpu=True, tims=active_tims)
+        #Save params
+        
+        self.current_bounds = (ux0, ux1, uy0, uy1)
+        if len(active_tims) == len(self.tractor.images):
+            #If only a subset of images are "in frame" we can calculate this later
+            self.ie_batch = ie_batch
+
+        tps[5] += time.time()-t1 
+        t1 = time.time()
+        chi_batch = self.tractor.getBatchChiImages(ux0=ux0, ux1=ux1, uy0=uy0, uy1=uy1, use_gpu=True, batch_psf=self.batch_psf, tims=active_tims, ie_stack=ie_batch)
+        tps[4] += time.time()-t1
+        #model_batch = self.tractor.getBatchModelImage(ux0=ux0, ux1=ux1, uy0=uy0, uy1=uy1, use_gpu=True, batch_psf=self.batch_psf, tims=active_tims)
+        #tps[6] += time.time()-t1
+        #cp.savetxt('chi_batch.txt', chi_batch.ravel())
+        #cp.savetxt('ie_batch.txt', ie_batch.ravel())
+        #cp.savetxt('model_batch.txt', model_batch.ravel())
+        #for i, tim in enumerate(active_tims):
+        #    print (f'BATCH {i=} {tim.getImage().max()=} {tim.getPsf().img.max()=} {ie_batch[i].max()=} {model_batch.max()=}')
+        #    print (f'MASKS {masks[i]}')
+
+        print ("chi_batch", chi_batch.shape, ie_batch.shape)
+        Chi_tensor = chi_batch.reshape((num_imgs, total_pixels))
+        t = time.time()
+        """
+        for i, (img, params) in enumerate(img_map.items()):
+            ie_full = img.getInvError(use_gpu=True)
+            mod_full = cp.asarray(self.tractor.getModelImage(img=img))
+            mask = self.tractor._getModelMaskFor(img, self.source)
+            #print (f'FULL {i=} {img.getImage().max()=}  {tim.getPsf().img.max()=} {ie_full.max()=} {mod_full.max()=} {ie_full.shape=}')
+            #print (cp.where(ie_full == ie_full.max()))
+            #print (f'MASK2 {mask}')
+        """
+        for i, (img, params) in enumerate(img_map.items()):
+            #print ("I", i, "IMG MAX", img.getImage().max(), img.getPsf().img.max())
+            #if i >= 3:
+            #    continue
+            # Fetch and crop to global bounds
+            # (Ensure getChiImage/getInvError return CuPy arrays to avoid transfers)
+            """
+            t1 = time.time()
+            chi_full = self.tractor.getChiImage(img=img, use_gpu=True)
+            ie_full = img.getInvError(use_gpu=True)
+            mod_full = cp.asarray(self.tractor.getModelImage(img=img))
+            tps[7] += time.time()-t1
+            img_h, img_w = chi_full.shape
+            #print ("CHI FULL", i, chi_full.shape)
+            #print (f'{chi_batch[i].max()=} {chi_full.max()=}')
+            #from tractor.batch_psf import plot_comparison
+            #from tractor.batch_psf import plot_one
+            #plot_one(model_batch[i].get(), "Model "+str(i))
+            #plot_one(mod_full.get(), "Model F"+str(i))
+            #plot_comparison(model_batch[i].get(), mod_full.get(), "Model "+str(i))
+
+            # 2. Determine the intersection between this image and the Global Box
+            # These are indices in the IMAGE coordinate system
+            y_start = max(uy0, 0)
+            y_end   = min(uy1, img_h)
+            x_start = max(ux0, 0)
+            x_end   = min(ux1, img_w)
+
+            # 3. Determine where that intersection lands in the GLOBAL coordinate system
+            # These are indices relative to the top-left of the (u_height, u_width) tensor
+            d_y_start = y_start - uy0
+            d_y_end   = y_end   - uy0
+            d_x_start = x_start - ux0
+            d_x_end   = x_end   - ux0
+
+            for p_idx, patch in params.items():
+                px0, px1, py0, py1 = patch.extent
+
+            #print ("CHI FULL", i, chi_full.shape)
+            #print ("SHAPES ", y_start, y_end, x_start, x_end, d_y_start, d_y_end, d_x_start, d_x_end)
+            #print ("Ps:", py0, py1, px0, px1)
+            chi_sub = chi_full[y_start:y_end, x_start:x_end]
+            #print (f'{chi_batch[i].max()=} {chi_full.max()=} {chi_sub.max()=} {chi_sub.shape=}')
+            #print ("WHERE", cp.where(chi_batch[i] == chi_batch[i].max()), cp.where(chi_full == chi_full.max()), cp.where(chi_sub == chi_sub.max()))
+            
+            # Map global bounds to image coordinates
+            # Note: Handle images with different sizes/offsets via slicing
+            # For simplicity, assuming images contain the global box:
+            #chi_crop = chi_full[uy0:uy1, ux0:ux1].ravel()
+            #ie_crop = ie_full[uy0:uy1, ux0:ux1].ravel()
+            
+            #print ("SHAPES", Chi_tensor.shape, Chi_tensor[i].shape, chi_crop.shape, ie_crop.shape, chi_full.shape, ie_full.shape)
+            #ie_sub = ie_full[y_start:y_end, x_start:x_end]
+            ie_sub = ie_full[py0:py1, px0:px1]
+            #mod_sub = mod_full[y_start:y_end, x_start:x_end]
+            mod_sub = mod_full[py0:py1, px0:px1]
+            #print ("IE SUB", ie_sub.shape, ie_sub.max(), cp.where(ie_sub == ie_sub.max()))
+            #if i < 3:
+            #    from tractor.batch_psf import plot_comparison
+            #    plot_comparison(model_batch[i].get(), mod_sub.get(), "Mod "+str(i))
+            #    plot_comparison(ie_batch[i].get(), ie_sub.get(), "IE "+str(i))
+            #    plot_comparison(chi_batch[i].get(), chi_sub.get(), "Chi "+str(i))
+
+            #print (f'{uy0=} {uy1=} {ux0=} {ux1=}', chi_full[uy0:uy1, ux0:ux1].shape)
+            #print ("IE", ie_batch[i].max(), ie_full.max(), ie_sub.max(), "MOD", model_batch[i].max(), mod_full.max(), mod_sub.max())
+            #Chi_tensor[i] = chi_crop * ie_crop # Pre-weighted by inverse error
+
+            # 4. Fill Chi_tensor (Pre-weighted by inverse error)
+            # We reshape the row to 2D for easy slicing
+            t1 = time.time()
+            chi_row_2d = Chi_tensor[i].reshape(u_height, u_width)
+            
+            # Only update the region where the image actually exists
+            # The rest of the row remains zeroed out
+            #chi_row_2d[d_y_start:d_y_end, d_x_start:d_x_end] = chi_batch[i] 
+            #chi_row_2d = chi_batch[i]
+            chi_row_2d[d_y_start:d_y_end, d_x_start:d_x_end] = chi_batch[i][d_y_start:d_y_end, d_x_start:d_x_end]
+            """
+            iex = ie_batch[i]
+            #tps[8] += time.time()-t1
+
+            #print ("CHI ROW2d", chi_row_2d[d_y_start:d_y_end, d_x_start:d_x_end].shape, chi_row_2d.shape, chi_row_2d.max(), chi_batch[i].shape, chi_batch[i].max())
+            #print (f'{chi_row_2d.sum()=} {chi_batch[i].sum()=} {chi_sub.sum()=}')
+            #print ("IE", ie_batch[i].max(), ie_full.max(), "MOD", model_batch[i].max(), mod_full.max())
+            #print ("ChiT", Chi_tensor[i].sum(), Chi_tensor[i].max(), Chi_tensor[i].shape, chi_row_2d[d_y_start:d_y_end, d_x_start:d_x_end].shape)
+            #print ("START COORDS", y_start, y_end, x_start, x_end)
+            #cp.savetxt('chi_row_2d_'+str(i)+'.txt', chi_row_2d)
+            #cp.savetxt('ie_full_'+str(i)+'.txt', ie_full)
+            #cp.savetxt('mod_full_'+str(i)+'.txt', mod_full)
+            #cp.savetxt('chi_full_'+str(i)+'.txt', chi_full)
+            #print ("MATCHES: ", cp.allclose(chi_batch[i], chi_row_2d, atol=1.e-5))
+            #print ("CMATCHES: ", cp.allclose(chi_batch[i], chi_sub, atol=1.e-5))
+            #print ("IE", ie_batch[i].shape, ie_full[y_start:y_end, x_start:x_end].shape, ie_sub.shape, ie_batch[i].max(), ie_full[y_start:y_end, x_start:x_end].max(), ie_sub.max())
+            #if ie_full[y_start:y_end, x_start:x_end].shape == ie_batch[i].shape:
+                #print ("MATCHES: ", cp.allclose(chi_batch[i], chi_row_2d, atol=1.e-5))
+                #print ("IE MATCH", cp.allclose(ie_batch[i], ie_full[y_start:y_end, x_start:x_end], atol=1.e-5))
+                #print ("MOD MATCH", cp.allclose(model_batch[i], mod_full[y_start:y_end, x_start:x_end], atol=1.e-5))
+
+            for p_idx, patch in params.items():
+                t1 = time.time()
+                px0, px1, py0, py1 = patch.extent
+                #dx0, dx1 = px0 - ux0, px1 - ux0
+                #dy0, dy1 = py0 - uy0, py1 - uy0
+                # Patch is already relative to image coordinates, 
+                # but we need to place it relative to the Global Box
+                dx0 = px0 - ux0
+                dx1 = px1 - ux0
+                dy0 = py0 - uy0
+                dy1 = py1 - uy0
+                
+                # View into the specific image/parameter row as a 2D grid for insertion
+                """
+                J_view = J_tensor[i, p_idx].reshape((u_height, u_width))
+                tps[17] += time.time()-t1
+                t1 = time.time()
+                """
+                """
+                t1 = time.time()
+                J_tensor[i, p_idx, dy0:dy1, dx0:dx1] = patch.getPatch(use_gpu=True)
+                gps[0] += time.time()-t1
+                """
+
+                #cJ_view = cJ_tensor[i, p_idx].reshape((u_height, u_width))
+                #tps[14] += time.time()-t1
+                #t1 = time.time()
+
+                #d_cpu = patch.getPatch()
+                #tps[15] += time.time()-t1
+                #t1 = time.time()
+                
+                """
+                # Weighted derivative: (deriv * inv_error)
+                d_gpu = patch.getPatch(use_gpu=True)
+                tps[18] += time.time()-t1
+                t1 = time.time()
+
+                #ie_full = img.getInvError(use_gpu=True)
+                #print (f'{d_gpu.shape=} {J_view.shape=} {ie_batch.shape=} {iex[dy0:dy1, dx0:dx1].shape=}')
+                #print (f'{dx0=} {dy0=} {dx1=} {dy1=} {px0=} {px1=} {py0=} {py1=}')
+                """
+
+                t1 = time.time()
+                #cJ_view[dy0:dy1, dx0:dx1] = d_cpu * iec[dy0:dy1, dx0:dx1]
+                #cJ_view[dy0:dy1, dx0:dx1] = d_cpu
+                cJ_tensor[i, p_idx, dy0:dy1, dx0:dx1] = patch.getPatch()
+                #cps[0] += time.time()-t1
+                tps[3] += time.time()-t1
+
+
+                """
+                patch.patch_gpu = None
+                t1 = time.time()
+                J_tensor2[i, p_idx, dy0:dy1, dx0:dx1] = patch.getPatch(use_gpu=True)*iex[dy0:dy1, dx0:dx1]
+                gps[6] += time.time()-t1
+                """
+
+                """
+                #J_view[dy0:dy1, dx0:dx1] = d_gpu * ie_batch[i][dy0:dy1, dx0:dx1]
+                J_view[dy0:dy1, dx0:dx1] = d_gpu * iex[dy0:dy1, dx0:dx1]
+                #print ("JView", J_view.sum(), "IEX", iex.shape, iex[dy0:dy1, dx0:dx1].shape, iex.max(), iex[dy0:dy1, dx0:dx1].max())
+                tps[19] += time.time()-t1
+                #J_view[dy0:dy1, dx0:dx1] = d_gpu * ie_full[py0:py1, px0:px1]
+                #J_view[dy0:dy1, dx0:dx1] = d_gpu * ie_full[py0:py1, px0:px1].astype(cp.float64)
+                #print ("D GPU", d_gpu.shape, ie_full.shape)
+                """
+
+        tps[6] += time.time()-t
+        t = time.time()
+        # 4. The "Two-Dot" Solution (The Big Win)
+        # Reshape J to (N_params, N_images * Total_Pixels)
+        # This effectively flattens the image and pixel dimensions into one "measurement" space
+        t = time.time()
+        #cJ_tensor = cp.asarray(cJ_tensor)*ie_batch.reshape((num_imgs, 1, total_pixels))
+        cJ_tensor = cp.asarray(cJ_tensor)
+        cps[2] += time.time()-t
+        t = time.time()
+        cJ_tensor *= ie_batch[:, cp.newaxis, :,:]
+        cps[3] += time.time()-t
+        """
+        t = time.time()
+        J_tensor *= ie_batch[:, cp.newaxis, :,:]
+        gps[3] += time.time()-t
+        """
+        t = time.time()
+        #print ("ALLCLOSE", cp.allclose(J_tensor, cJ_tensor))
+        #J_flat = J_tensor.transpose(1, 0, 2).reshape(num_params, -1)
+        cJ_flat = cJ_tensor.transpose(1, 0, 2, 3).reshape(num_params, -1)
+        cJ_flat = cp.ascontiguousarray(cJ_flat) # Force BLAS-friendly layout
+        cps[9] += time.time()-t
+        Chi_flat = Chi_tensor.ravel()
+        #print ("J_flat", J_flat.shape, J_flat.sum(), J_flat.max())
+        #print ("Chi_flat", Chi_flat.sum(), Chi_flat.max())
+        #print ("Chi batch", chi_batch.sum(), chi_batch.max()) 
+
+        # Gradient: G = J_flat @ Chi_flat
+        # Result: (N_params,)
+        G_full = cJ_flat.dot(Chi_flat)
+
+        # Hessian: H = J_flat @ J_flat^T
+        # Result: (N_params, N_params)
+        H_full = cJ_flat.dot(cJ_flat.T)
+        tps[10] += time.time()-t
+        cps[4] += time.time()-t
+
+        """
+        t = time.time()
+        J_flat = J_tensor.transpose(1, 0, 2, 3).reshape(num_params, -1)
+        #J_flat = cp.ascontiguousarray(J_flat) # Force BLAS-friendly layout
+        Chi_flat = Chi_tensor.ravel()
+        print ("J_flat", J_flat.shape, J_flat.sum(), J_flat.max())
+        print ("Chi_flat", Chi_flat.sum(), Chi_flat.max())
+        print ("Chi batch", chi_batch.sum(), chi_batch.max())
+
+        # Gradient: G = J_flat @ Chi_flat
+        # Result: (N_params,)
+        G_full = J_flat.dot(Chi_flat)
+
+        # Hessian: H = J_flat @ J_flat^T
+        # Result: (N_params, N_params)
+        H_full = J_flat.dot(J_flat.T)
+        gps[4] += time.time()-t
+
+
+        t = time.time()
+        J_flat2 = J_tensor2.transpose(1, 0, 2, 3).reshape(num_params, -1)
+        #J_flat = cp.ascontiguousarray(J_flat) # Force BLAS-friendly layout
+        Chi_flat = Chi_tensor.ravel()
+
+        # Gradient: G = J_flat @ Chi_flat
+        # Result: (N_params,)
+        G_full = J_flat2.dot(Chi_flat)
+
+        # Hessian: H = J_flat @ J_flat^T
+        # Result: (N_params, N_params)
+        H_full = J_flat2.dot(J_flat2.T)
+        gps[7] += time.time()-t
+        """
+
+        return H_full, G_full, num_imgs
+
+
+    def compute_update(self, allderivs):
+        """
+        Calculates the total Hessian (H) and Gradient (G) for the given derivatives
+        across all images. Returns (H, G) as CuPy arrays.
+        
+        allderivs: list of lists [ (param0) [ (patch, img), ... ], (param1) [...] ]
+        """
+        t = time.time()
+        num_params = len(allderivs)
+        #print (f'{allderivs=}')
+        #print (f'GPU {num_params=}')
+        if num_params == 0:
+            return None, None, 0
+
+        # 1. Pivot: Group patches by Image to minimize GPU overhead
+        # Structure: img -> {global_param_idx: PatchObject}
+        img_map = {}
+        for p_idx, patches in enumerate(allderivs):
+            for patch, img in patches:
+                if patch is None or patch.patch is None:
+                    continue
+                if img not in img_map:
+                    img_map[img] = {}
+                img_map[img][p_idx] = patch
+
+        # 1. Determine the Global Super-Box across ALL images
+        all_x0, all_x1, all_y0, all_y1 = [], [], [], []
+        for patches in allderivs:
+            for patch, _ in patches:
+                if patch:
+                    all_x0.append(patch.extent[0])
+                    all_x1.append(patch.extent[1])
+                    all_y0.append(patch.extent[2])
+                    all_y1.append(patch.extent[3])
+
+        if len(all_x0) == 0:
+            return None, None, 0
+        ux0, ux1 = int(min(all_x0)), int(max(all_x1))
+        uy0, uy1 = int(min(all_y0)), int(max(all_y1))
+        u_height, u_width = uy1 - uy0, ux1 - ux0
+        total_pixels = u_height * u_width
+        num_imgs = len(img_map)
+        num_params = len(allderivs)
+
+        # 2. Pre-allocate Tensors on GPU
+        # J: (N_images, N_params, Total_Pixels)
+        # Chi: (N_images, Total_Pixels)
+        J_tensor = cp.zeros((num_imgs, num_params, total_pixels), dtype=cp.float64)
+        Chi_tensor = cp.zeros((num_imgs, total_pixels), dtype=cp.float64)
+        tps[11] += time.time()-t
+
+        t = time.time()
+        for i, (img, params) in enumerate(img_map.items()):
+            #print ("OG I", i, "IMG MAX", img.getImage().max())
+            #if i >= 3:
+            #    continue
+            # Fetch and crop to global bounds
+            # (Ensure getChiImage/getInvError return CuPy arrays to avoid transfers)
+            t1 = time.time()
+            chi_full = self.tractor.getChiImage(img=img, use_gpu=True)
+            ie_full = img.getInvError(use_gpu=True)
+            mod_full = cp.asarray(self.tractor.getModelImage(img=img))
+            tps[12] += time.time()-t1
+            img_h, img_w = chi_full.shape
+
+            # 2. Determine the intersection between this image and the Global Box
+            # These are indices in the IMAGE coordinate system
+            y_start = max(uy0, 0)
+            y_end   = min(uy1, img_h)
+            x_start = max(ux0, 0)
+            x_end   = min(ux1, img_w)
+
+            # 3. Determine where that intersection lands in the GLOBAL coordinate system
+            # These are indices relative to the top-left of the (u_height, u_width) tensor
+            d_y_start = y_start - uy0
+            d_y_end   = y_end   - uy0
+            d_x_start = x_start - ux0
+            d_x_end   = x_end   - ux0
+            
+            # Map global bounds to image coordinates
+            # Note: Handle images with different sizes/offsets via slicing
+            # For simplicity, assuming images contain the global box:
+            #chi_crop = chi_full[uy0:uy1, ux0:ux1].ravel()
+            #ie_crop = ie_full[uy0:uy1, ux0:ux1].ravel()
+            
+            # 4. Fill Chi_tensor (Pre-weighted by inverse error)
+            # We reshape the row to 2D for easy slicing
+            t1 = time.time()
+            chi_row_2d = Chi_tensor[i].reshape(u_height, u_width)
+            
+            # Only update the region where the image actually exists
+            # The rest of the row remains zeroed out
+            chi_row_2d[d_y_start:d_y_end, d_x_start:d_x_end] = (
+                chi_full[y_start:y_end, x_start:x_end].astype(cp.float64)
+            )
+            #print (f"OLD {i=} {y_start=} {y_end=} {x_start=} {x_end=} {d_y_start=} {d_y_end=} {d_x_start=} {d_x_end=}")
+            #print (f"IE {ie_full.max()=} {ie_full[y_start:y_end, x_start:x_end].max()=}")
+            #print ("ChiT", Chi_tensor[i].sum(), Chi_tensor[i].max(), Chi_tensor[i].shape, chi_row_2d[d_y_start:d_y_end, d_x_start:d_x_end].shape)
+
+            tps[13] += time.time()-t1
+
+            for p_idx, patch in params.items():
+                px0, px1, py0, py1 = patch.extent
+                #dx0, dx1 = px0 - ux0, px1 - ux0
+                #dy0, dy1 = py0 - uy0, py1 - uy0
+                # Patch is already relative to image coordinates, 
+                # but we need to place it relative to the Global Box
+                dx0 = px0 - ux0
+                dx1 = px1 - ux0
+                dy0 = py0 - uy0
+                dy1 = py1 - uy0
+                
+                # View into the specific image/parameter row as a 2D grid for insertion
+                J_view = J_tensor[i, p_idx].reshape((u_height, u_width))
+                
+                # Weighted derivative: (deriv * inv_error)
+                d_gpu = patch.getPatch(use_gpu=True)
+                J_view[dy0:dy1, dx0:dx1] = d_gpu * ie_full[py0:py1, px0:px1]
+                #print ("CPU IE Ps:",py0, py1, px0, px1, ie_full[py0:py1, px0:px1].max())
+                #print ("JView", J_view.sum(), "IE", ie_full[py0:py1, px0:px1].shape, ie_full[py0:py1, px0:px1].max())
+
+        tps[14] += time.time()-t
+        t = time.time()
+        # 4. The "Two-Dot" Solution (The Big Win)
+        # Reshape J to (N_params, N_images * Total_Pixels)
+        # This effectively flattens the image and pixel dimensions into one "measurement" space
+        J_flat = J_tensor.transpose(1, 0, 2).reshape(num_params, -1)
+        Chi_flat = Chi_tensor.ravel()
+        print ("J_flat", J_flat.shape, J_flat.sum(), J_flat.max())
+        print ("Chi_flat", Chi_flat.sum(), Chi_flat.max())
+
+        # Gradient: G = J_flat @ Chi_flat
+        # Result: (N_params,)
+        G_full = J_flat.dot(Chi_flat)
+
+        # Hessian: H = J_flat @ J_flat^T
+        # Result: (N_params, N_params)
+        H_full = J_flat.dot(J_flat.T)
+        tps[15] += time.time()-t
+        return H_full, G_full, num_imgs
+
+    def compute_update_old(self, allderivs):
+        """
+        Calculates the total Hessian (H) and Gradient (G) for the given derivatives
+        across all images. Returns (H, G) as CuPy arrays.
+        
+        allderivs: list of lists [ (param0) [ (patch, img), ... ], (param1) [...] ]
+        """
+        num_params = len(allderivs)
+        #print (f'{allderivs=}')
+        print (f'GPU {num_params=}')
+        if num_params == 0:
+            return None, None
+
+        # 1. Pivot: Group patches by Image to minimize GPU overhead
+        # Structure: img -> {global_param_idx: PatchObject}
+        img_map = {}
+        for p_idx, patches in enumerate(allderivs):
+            for patch, img in patches:
+                if patch is None or patch.patch is None:
+                    continue
+                if img not in img_map:
+                    img_map[img] = {}
+                img_map[img][p_idx] = patch
+
+        # 2. Initialize H and G on GPU
+        # We use float64 for the accumulation to match the precision of the CPU engine
+        H_full = cp.zeros((num_params, num_params), dtype=cp.float64)
+        G_full = cp.zeros(num_params, dtype=cp.float64)
+        #A = []
+        #B = []
+
+        xicsum = 0
+        icsum = 0
+
+        # 3. Process image by image
+        idx = 0
+        ni = 0
+        for img, params in img_map.items():
+            t = time.time()
+            H = cp.zeros((num_params, num_params), dtype=cp.float64)
+            G = cp.zeros(num_params, dtype=cp.float64)
+            R = None
+            if self.cpucomp is not None:
+                R = self.cpucomp[idx]
+                cx,cx_icov,cA,ccolscales,cB,cAo = R
+                print ("R", R)
+                idx+=1
+            #currA = [] 
+            # Calculate the "Super-Bounding Box" for all patches in this image
+            all_x0 = [p.extent[0] for p in params.values()]
+            all_x1 = [p.extent[1] for p in params.values()]
+            all_y0 = [p.extent[2] for p in params.values()]
+            all_y1 = [p.extent[3] for p in params.values()]
+
+            ux0, ux1 = min(all_x0), max(all_x1)
+            uy0, uy1 = min(all_y0), max(all_y1)
+            u_shape = (uy1 - uy0, ux1 - ux0)
+            tps[2] += time.time()-t
+            t = time.time()
+            
+            # Fetch residuals (chi) and inverse error for this image, cropped to the Super-Box
+            # chi = (data - model) * inverr
+            chi_full = self.tractor.getChiImage(img=img, use_gpu=True)
+            ie_full = img.getInvError(use_gpu=True)
+            tps[3] += time.time()-t
+            t = time.time()
+            
+            # Transfer to GPU (float32 is sufficient for individual pixel math)
+            chi_gpu = cp.array(chi_full[uy0:uy1, ux0:ux1].astype(np.float64))
+            ie_gpu = cp.array(ie_full[uy0:uy1, ux0:ux1].astype(np.float64))
+            tps[4] += time.time()-t
+            t = time.time()
+            #print ("chi", chi_gpu.shape, chi_gpu.max())
+            #cp.savetxt('gchi.txt', chi_gpu)
+            #B.append(chi_gpu.get())
+            """
+            if R is not None:
+                try:
+                    assert(np.allclose(cB, chi_gpu.get().ravel()))
+                    print (f'{self.tractor.catalog[0]=} {img=} B match')
+                except AssertionError as ex:
+                    print (f"{self.tractor.catalog[0]=} {img=} B does not match!")
+                    chi_gpu = cp.asarray(cB).rehsape(u_shape)
+            """
+
+            # Store padded Jacobians (J = deriv * inverr)
+            js_gpu = {}
+            for p_idx, patch in params.items():
+                J_full = cp.zeros(u_shape, dtype=cp.float64)
+
+                # Relative offsets within the Super-Box
+                px0, px1, py0, py1 = patch.extent
+                dx0, dx1 = px0 - ux0, px1 - ux0
+                dy0, dy1 = py0 - uy0, py1 - uy0
+
+                # Insert the derivative patch and weight by inverse error
+                d_gpu = cp.array(patch.getPatch(use_gpu=True).astype(cp.float64))
+                J_full[dy0:dy1, dx0:dx1] = d_gpu * ie_gpu[dy0:dy1, dx0:dx1]
+                """
+                if R is not None:
+                    try:
+                        assert(np.allclose(cA[:,p_idx], J_full.get().ravel()))
+                        print (f'{self.tractor.catalog[0]=} {img=} A match')
+                    except AssertionError as ex:
+                        print (f'{self.tractor.catalog[0]=} {img=} {p_idx=} A does not match')
+                        J_full = cp.asarray(cA[:,p_idx]).reshape(u_shape)
+                """
+
+                js_gpu[p_idx] = J_full
+
+                # Accumulate Gradient: G = J^T * chi
+                G[p_idx] += cp.sum((J_full * chi_gpu).astype(cp.float64))
+                #print ("J", J_full.shape, J_full.max())
+                #print ("G", G.shape, G.max())
+                #cp.savetxt('gj_'+str(p_idx)+'.txt', J_full)
+                #currA.append(J_full.get())
+            tps[5] += time.time()-t
+            t = time.time()
+
+            #A.append(currA)
+            # 4. Accumulate Hessian Cross-Terms (H = J^T * J)
+            p_indices = sorted(js_gpu.keys())
+            for i, p1 in enumerate(p_indices):
+                J1 = js_gpu[p1].astype(cp.float64)
+                for p2 in p_indices[i:]:
+                    val = cp.sum(J1 * js_gpu[p2].astype(cp.float64))
+                    H[p1, p2] += val
+                    if p1 != p2:
+                        H[p2, p1] += val
+            
+            # Clean up image-specific GPU memory
+            del js_gpu, chi_gpu, ie_gpu
+            #cp.savetxt("ggrad.txt", G)
+            #cp.savetxt("ghess.txt", H)
+            """
+            gpux = cp.linalg.lstsq(H, G)[0]
+            print (f'{idx=}')
+            print ("SHAPES", cx_icov.shape, cx.shape, G.shape, H.shape, gpux.shape)
+            print (f'{cx_icov=}')
+            print (f'{G=}')
+            print (f'{H=}')
+            print (f'{gpux=} {self.tractor.catalog[0]=} {img=}')
+            print (f'{cx=}')
+            """
+            H_full += H
+            G_full += G
+            ni += 1
+            tps[6] += time.time()-t
+            """
+            dp = np.dot(cx_icov, cx)
+            print (f'{dp=}')
+            ddp = np.dot(cx_icov.astype(np.float64), cx.astype(np.float64))
+            print (f'{ddp=}')
+
+            xicsum = xicsum + np.dot(cx_icov, cx)
+            icsum = icsum + cx_icov
+
+            print (f'{H_full=}')
+            print (f'{G_full=}')
+            print (f'{xicsum=}')
+            print (f'{icsum=}')
+            if R is not None:
+                try:
+                    assert(np.allclose(cx_icov, H.get()))
+                    print (f'{self.tractor.catalog[0]=} {img=} Hess match')
+                except AssertionError as ex:
+                    print (f'{self.tractor.catalog[0]=} {img=} Hess does not match')
+                try:
+                    assert(np.allclose(cx, gpux))
+                    print (f'{self.tractor.catalog[0]=} {img=} X match')
+                except AssertionError as ex:
+                    print (f'{self.tractor.catalog[0]=} {img=} X does not match')
+            """
+            #print (f'{gpux=} {self.tractor.catalog[0]=}')
+            #import sys
+            #sys.exit(-1)
+
+        """
+        A = np.asarray(A)
+        B = np.asarray(B)
+        A = cp.asarray(A)
+        B = cp.asarray(B)
+        print ("A", A.shape)
+        print ("B", B.shape)
+        cp.savetxt("ga.txt", A.ravel())
+        cp.savetxt("gb.txt", B.ravel())
+        Xicov = cp.matmul(A.swapaxes(-1,-2), A)
+        #print ("Xicov", Xicov)
+        # Pre-scale the columns of A
+        colscales = cp.sqrt(cp.diagonal(Xicov, axis1=1, axis2=2))
+        colscales[colscales == 0] = 1.
+        print ("COLSCALES", colscales.shape)
+        cp.savetxt("gcols.txt", colscales.ravel())
+        """
+        #print ("J", J_full.shape, "Hess", H.shape, "Grad", G.shape)
+        #cp.savetxt("gj.txt", J_full.ravel())
+        #cp.savetxt("ggrad.txt", G.ravel())
+        #cp.savetxt("ghess.txt", H.ravel())
+        #import sys
+        #sys.exit(-1)
+
+        return H_full, G_full, ni
+
+    
+    def tryUpdates_gpu_old(self, tractor, X, alphas=None, check_step=None):
+        """
+        GPU-accelerated version of the line search.
+        X: The update direction (numpy array)
+        """
+        # 1. Setup initial state
+        p0 = tractor.getParams()
+        logprob_before = tractor.getLogProb()
+        logprob_best = logprob_before
+        alpha_best = None
+        p_best = p0
+
+        # 2. Get the candidate steps (respecting bounds and max_step)
+        # This uses the CPU logic from ConstrainedOptimizer to ensure consistency
+        steps = self.optimizer.getParameterSteps(tractor, X, alphas)
+
+        if len(steps) == 0:
+            self.optimizer.last_step_hit_limit = True
+            self.optimizer.hit_limit = True
+            return 0., 0.
+
+        # 3. Line Search Loop
+        for alpha, p, step_limit, hit_limit in steps:
+            if hit_limit:
+                self.optimizer.hit_limit = True
+
+            # Update the tractor object's state (required for LogPrior and potential callbacks)
+            tractor.setParams(p)
+
+            if check_step is not None:
+                r = check_step(optimizer=self.optimizer, tractor=tractor, X=X, alpha=alpha)
+                if not r:
+                    break
+
+            # --- GPU Likelihood Calculation ---
+            total_chi2 = 0.0
+
+            # We iterate over the images, but the data stays on GPU
+            for i, img in enumerate(tractor.images):
+                # Render the source at the NEW parameters on the GPU
+                # This should return a CuPy array representing the patch
+                model_patch = self.render_source_gpu(img, tractor)
+
+                if model_patch is None:
+                    continue
+
+                # data_gpu and invvar_gpu should be pre-cached CuPy arrays
+                data = self.img_data_gpu[i]
+                invvar = self.img_invvar_gpu[i]
+
+                # Use float64 for the accumulation to prevent precision-driven divergence
+                diff = (data - model_patch)
+                chi2_img = cp.sum((diff**2) * invvar, dtype=cp.float64)
+                total_chi2 += float(chi2_img.get())
+
+            # Combine with Prior (CPU side)
+            log_prior = tractor.getLogPrior()
+            logprob = -0.5 * total_chi2 + log_prior
+
+            # --- Early Exit and Best-Track Logic ---
+            if not np.isfinite(logprob):
+                break
+
+            if logprob < (logprob_best - 1.0):
+                # Significant degradation; stop the line search
+                break
+
+            if logprob > logprob_best:
+                self.optimizer.last_step_hit_limit = hit_limit
+                alpha_best = alpha
+                logprob_best = logprob
+                p_best = p
+
+        # 4. Finalize state
+        tractor.setParams(p_best)
+
+        if alpha_best is None:
+            return 0., 0.
+
+        return logprob_best - logprob_before, alpha_best
+
+    def tryUpdates_gpu(self, X, alphas=None, check_step=None):
+        t_start = time.time()
+        (ux0, ux1, uy0, uy1) = self.current_bounds
+        if self.ie_batch is None:
+            self.ie_batch = self.tractor.getBatchInvErrors(ux0=ux0, ux1=ux1, uy0=uy0, uy1=uy1, use_gpu=True)
+
+        # 1. Prepare Alphas (inject 0.0 at the front)
+        if alphas is None:
+            alphas = np.append(0.0, np.append(2.**np.arange(-10, 1), [np.sqrt(2.), 2.]))
+        else:
+            alphas = np.unique(np.append(0.0, alphas))
+
+        # 2. Get Steps
+        #s2 = self.getParameterSteps_gpu(self.tractor, X, alphas)
+        #print (f'{s2=}')
+        steps = self.getParameterSteps(X, alphas, firstAlphaIsZero=True)
+        candidate_ps = [s['p'] for s in steps]
+        #print (f'{alphas=} {steps=} {candidate_ps=}')
+        #t1 = time.time()
+        #-#lp_global_before = self.tractor.getLogProb()
+        #tu[7] += time.time()-t1
+
+        # 3. The Big Batch Evaluation
+        # We pass the cached bounds and IE stack to avoid re-calculation
+        t1 = time.time()
+        logprobs = self.tractor.getLogProbBatch(
+            candidate_ps,
+            bounds=self.current_bounds,
+            ie_stack=self.ie_batch,
+            use_gpu=True
+        )
+        tu[8] += time.time()-t1
+
+        # logprobs[0] is our baseline (alpha=0)
+        # 3. Use the GPU's alpha=0 as the local baseline
+        #lp_before = float(logprobs[0])
+        lps_cpu = cp.asnumpy(logprobs)
+        lp_before = lps_cpu[0]
+        #print (f'{lps_cpu=}')
+        #-#lp_local_baseline = lp_global_before-lps_cpu[0] 
+        #-#lps_cpu += lp_local_baseline
+        #-#lp_before = lp_global_before
+        #-#print (f'{lp_global_before=} {lps_cpu=}')
+
+        lp_best = lp_before
+        alpha_best = 0.0
+        p_best = candidate_ps[0]
+        hit_limit_best = False
+
+        # 4. Standard Line Search logic (Identify best alpha)
+        for i, step in enumerate(steps[1:], start=1):
+            lp = lps_cpu[i]
+            
+            # Tractor exit conditions: significantly worse or non-finite
+            if lp < (lp_best - 1.0) or not np.isfinite(lp):
+                break
+                
+            if lp > lp_best:
+                lp_best = lp
+                alpha_best = step['alpha']
+                p_best = step['p']
+                hit_limit_best = step['hit_limit']
+
+        # 5. Finalize State
+        self.tractor.setParams(p_best)
+        self.last_step_hit_limit = hit_limit_best
+        #print ("Pbest", p_best)
+        #print ("LOGPROB", lp_best, lp_before)
+        #print ("ALPHA", alpha_best, hit_limit_best, self.last_step_hit_limit)
+        
+        return lp_best - lp_before, alpha_best
+
+
+    def getParameterSteps(self, X, alphas=None, firstAlphaIsZero=False):
+        t = time.time()
+        if alphas is None:
+            alphas = np.append(2.**np.arange(-10, 1), [np.sqrt(2.), 2.])
+
+        p0 = self.tractor.getParams()
+        max_step_size = self.tractor.getMaxStep()
+        lowers = self.tractor.getLowerBounds()
+        uppers = self.tractor.getUpperBounds()
+        #print (f'{p0=} {max_step_size=} {lowers=} {uppers=}')
+
+        X_np = cp.asnumpy(X) # Ensure we work on CPU for the logic
+        results = []
+
+        for i, alpha in enumerate(alphas):
+            do_break = False
+            step_limit = False
+            hit_limit = False
+
+            # Apply max_step_size
+            for i, mx in enumerate(max_step_size):
+                if mx is None or abs(X_np[j]) == 0: continue
+                step = alpha * abs(X_np[j])
+                if step > mx:
+                    step_limit = True
+                    do_break = True
+                    alpha = mx / abs(X_np[j])
+
+            # Apply bounds and compute p
+            p = []
+            for p_start, s, l, u in zip(p0, X_np, lowers, uppers):
+                px = p_start + alpha * s
+                if l is not None and px < l:
+                    px = l
+                    hit_limit = True
+                if u is not None and px > u:
+                    px = u
+                    hit_limit = True
+                p.append(px)
+
+            if alpha < self.tiny_alpha and alpha != 0:
+                #if i > 0 or not firstAlphaIsZero or alpha != 0:
+                break
+
+            results.append({
+                'alpha': alpha,
+                'p': np.array(p),
+                'step_limit': step_limit,
+                'hit_limit': hit_limit
+            })
+
+            if do_break:
+                break
+        #print (f'{results=}')
+        tu[9] += time.time()-t
+        return results
+
+    def getParameterSteps_gpu(self, tractor, step_direction, alphas=None):
+        if alphas is None:
+            # Default alphas: 1/1024 to 1, then sqrt(2) and 2
+            alphas = np.append(2.**np.arange(-10, 1), [np.sqrt(2.), 2.])
+
+        p0 = np.array(tractor.getParams())
+        lowers = np.array([x if x is not None else -np.inf for x in tractor.getLowerBounds()])
+        uppers = np.array([x if x is not None else  np.inf for x in tractor.getUpperBounds()])
+        max_steps = np.array([x if x is not None else np.inf for x in tractor.getMaxStep()])
+
+        step_direction = np.array(step_direction)
+        results = []
+
+        for alpha in alphas:
+            # 1. Check Max Step Size
+            # If alpha * |dir| > max_step, we cap alpha and then BREAK
+            step_magnitudes = alpha * np.abs(step_direction)
+            over_step = step_magnitudes > max_steps
+
+            do_break = False
+            step_limit = False
+            if np.any(over_step):
+                # Find the parameter that forces the smallest alpha
+                alpha = np.min(max_steps[over_step] / np.abs(step_direction[over_step]))
+                step_limit = True
+                do_break = True
+                self.stepLimited = True
+
+            # 2. Check Bounds
+            # px = p0 + alpha * s
+            px_trial = p0 + alpha * step_direction
+            hit_limit = False
+
+            # Check lower bounds
+            too_low = (lowers != -np.inf) & (px_trial < lowers)
+            if np.any(too_low):
+                alpha = np.min((lowers[too_low] - p0[too_low]) / step_direction[too_low])
+                hit_limit = True
+
+            # Check upper bounds
+            too_high = (uppers != np.inf) & (px_trial > uppers)
+            if np.any(too_high):
+                alpha = np.min((uppers[too_high] - p0[too_high]) / step_direction[too_high])
+                hit_limit = True
+
+            if alpha < self.tiny_alpha:
+                break
+
+            # Final param calculation (clamped for safety)
+            p_final = np.clip(p0 + alpha * step_direction, lowers, uppers)
+            results.append((alpha, p_final.tolist(), step_limit, hit_limit))
+
+            if do_break:
+                break
+
+        return results
 
 '''
 A mixin class for LsqrOptimizer that does the linear update direction step
@@ -36,9 +1053,53 @@ class FactoredOptimizer(object):
         self.ps = None
         super().__init__(*args, **kwargs)
 
-    def getSingleImageUpdateDirection(self, tr, max_size=0, **kwargs):
+    def gsud_comp(self, tr, **kwargs):
+        from tractor import Images
+        img_opts = []
+        imgs = tr.images
+        mm = tr.modelMasks
+
+        #Remove 'priors' from kwargs
+        orig_priors = kwargs.pop('priors', True)
+        max_size = 0
+        for i,img in enumerate(imgs):
+            tr.images = Images(img)
+            if mm is not None:
+                tr.modelMasks = [mm[i]]
+            #Run with PRIORS = FALSE
+            r = self.gsud1(tr, priors=False, max_size=max_size, **kwargs)
+            if r is None:
+                continue
+            x,x_icov,A,colscales,B,Ao = r
+            max_size = max(max_size, len(x))
+            #print('FO: X', x, 'x_icov', x_icov)
+            img_opts.append(r)
+        tr.images = imgs
+        tr.modelMasks = mm
+        return img_opts
+
+    def gsud1(self, tr, max_size=0, **kwargs):
+        t = time.time()
         allderivs = tr.getDerivs()
+        tt[7] += time.time()-t
+        print ("GSUD ALLDERIVS", len(allderivs), tt[7])
         r = self.getUpdateDirection(tr, allderivs, get_A_matrix=True, max_size=max_size, **kwargs)
+        if r is None:
+            return None
+        x,A,colscales,B,Ao = r
+        icov = np.matmul(A.T, A)
+        return x, icov, A, colscales, B, Ao
+
+
+    def getSingleImageUpdateDirection(self, tr, max_size=0, **kwargs):
+        t = time.time()
+        allderivs = tr.getDerivs()
+        tt[7] += time.time()-t
+        tps[0] += time.time()-t
+        t = time.time()
+        #print ("GSUD ALLDERIVS", len(allderivs), tt[7])
+        r = self.getUpdateDirection(tr, allderivs, get_A_matrix=True, max_size=max_size, **kwargs)
+        tps[1] += time.time()-t
         if r is None:
             return None
         x,A,colscales,B,Ao = r
@@ -83,7 +1144,9 @@ class FactoredOptimizer(object):
                     plt.title('dflux')
             self.ps.savefig()
 
+        t = time.time()
         icov = np.matmul(A.T, A)
+        tps[2] += time.time()-t
         del A
         return x, icov
 
@@ -118,6 +1181,11 @@ class FactoredOptimizer(object):
         # If image parameters are being fit, use the base code (eg in lsqr_optimizer.py)
         # to fit those, and prepend them to the results below.
         t = time.time()
+        tct[1] += 1
+        #tr.images = tr.images[:5]
+        #if tct[1] > 2:
+        #    import sys
+        #    sys.exit(0)
         x_imgs = None
         image_thawed = tr.isParamThawed('images')
         if image_thawed:
@@ -140,8 +1208,10 @@ class FactoredOptimizer(object):
             return None
         #Store original value of priors
         orig_priors = kwargs['priors']
+        print (f'{orig_priors=}')
         img_opts = self.getSingleImageUpdateDirections(tr, **kwargs)
         tt[5] += time.time()-t
+        t = time.time()
         if len(img_opts) == 0:
             if x_imgs is not None:
                 return x_imgs
@@ -149,9 +1219,13 @@ class FactoredOptimizer(object):
         # ~ inverse-covariance-weighted sum of img_opts...
         xicsum = 0
         icsum = 0
-        for x,ic in img_opts:
-            xicsum = xicsum + np.dot(ic, x)
-            icsum = icsum + ic
+        if len(img_opts) == 1 and len(img_opts[0]) == 3:
+            xicsum, icsum, _ = img_opts[0]
+        else:
+            for x,ic in img_opts:
+                #print(f'{x=} {ic=} {tr.catalog[0]=}')
+                xicsum = xicsum + np.dot(ic, x)
+                icsum = icsum + ic
         #C = np.linalg.inv(icsum)
         #x = np.dot(C, xicsum)
         #print (f'{icsum=} {xicsum=}')
@@ -171,8 +1245,17 @@ class FactoredOptimizer(object):
             else:
                 print (f"WARNING: Prior shape mismatch {icsum.shape=} {xicsum.shape=} {priors_ATA.shape=} {priors_ATB.shape=}; using CPU mode instead.")
                 return super().getLinearUpdateDirection(tr, **kwargs)
-        x,_,_,_ = np.linalg.lstsq(icsum, xicsum, rcond=None)
+        try:
+            x,_,_,_ = np.linalg.lstsq(icsum, xicsum, rcond=None)
+        except Exception as ex:
+            print ("WARNING: lstsq failed "+str(ex)+"; using CPU version")
+            return super().getLinearUpdateDirection(tr, **kwargs)
+        tt[6] += time.time()-t
         #print (f'{tt=}')
+        #print (f'{tps=}')
+        #print ("Final X: ",x, "Source", tr.catalog[0])
+        #import sys
+        #sys.exit(-1)
         if x_imgs is not None:
             x = np.append(x_imgs, x)
         #print (f'{icsum=} {xicsum=}')
@@ -204,12 +1287,36 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
 
     def printTiming(self):
         print ("Times:",tt,tct)
+        print ("PSTimes: ", tps)
+        print ("CPSTimes ", cps)
+        print ("GPSTimes:", gps)
+        print ("TU Times:", tu, tuc)
+
+    def printMemory(self, tag=""):
+        import cupy as cp
+        import datetime
+        free_mem, total_mem = cp.cuda.runtime.memGetInfo()
+        mempool = cp.get_default_memory_pool()
+        used_bytes = mempool.used_bytes()
+        tot_bytes = mempool.total_bytes()
+        print (f'{tag=} {free_mem=} {total_mem=}; This mempool {used_bytes=} {tot_bytes=} at ',datetime.datetime.now())
+        if free_mem/1.e+9 < 20:
+            import gc
+            print ("Freeing memory")
+            gc.collect()
+            print (f'{tag=} {free_mem=} {total_mem=}; This mempool {used_bytes=} {tot_bytes=} at ',datetime.datetime.now())
+            print ("GPU free all blocks")
+            mpool = cp.get_default_memory_pool()
+            mpool.free_all_blocks()
+            print (f'{tag=} {free_mem=} {total_mem=}; This mempool {used_bytes=} {tot_bytes=} at ',datetime.datetime.now())
+        sys.stdout.flush()
 
     def getSingleImageUpdateDirections(self, tr, **kwargs):
         #import traceback
         #traceback.print_stack()
         print ("GPU getSingleImageUpdateDirections")
-        #print ("profile galaxy", isinstance(tr.catalog[0], ProfileGalaxy))
+        print ("profile galaxy", isinstance(tr.catalog[0], ProfileGalaxy))
+        print ("len", len(tr.catalog), "Nimages", len(tr.images))
         R_gpu = None
         R_cpu = None
         R_gpuv = None
@@ -219,6 +1326,123 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
             if self._gpumode >= 10:
                 print ("Skipping non-profile galaxy")
                 return []
+            if self._gpumode == 2 and isinstance(tr.catalog[0], PointSource):
+                tct[5] += 1
+                #print ("TCT5 PSCOUNT", tct[5])
+                #im = tr.images
+                #mm = tr.modelMasks
+                #tr.images = tr.images[:1]
+                #tr.modelMasks = tr.modelMasks[:1]
+                t = time.time()
+                # Initialize the GPU Fitter
+                print ("Running new GPU point source fitter...")
+                # Initialize and CACHE the fitter on self
+                self.current_fitter = GPUFriendlyPointSourceFitter(tr, tr.catalog[0], tr.images)
+                #R_cpu = super().gsud_comp(tr, **kwargs)
+                #self.current_fitter.add_comp(R_cpu)
+                tx1 = time.time()
+                allderivs = tr.getDerivs()
+                tt[7] += time.time()-tx1
+                #print ("GPUPS ALLDERIVS", len(allderivs), tt[7])
+                tps[0] += time.time()-t
+
+                # Get the update
+                # Solve A^T A x = A^T b
+                """
+                tx1 = time.time()
+                ohess, ograd, ni = self.current_fitter.compute_update(allderivs)
+                #ohess, ograd, ni = self.current_fitter.compute_update_old(allderivs) # Updated to use internal G
+                t5[0] += time.time()-tx1
+                ox,_,_,_ = np.linalg.lstsq(ohess.get(), ograd.get(), rcond=None)
+                print (f'OLD {ohess=} {ograd=} {ni=} {ox=}')
+                #self.current_fitter.get_batch_psf()
+                hess, grad, x = ohess, ograd, ox
+                """
+
+                tx1 = time.time()
+                hess, grad, ni = self.current_fitter.compute_update_vec(allderivs) # Updated to use internal G
+                t5[1] += time.time()-tx1
+                #x,_,_,_ = np.linalg.lstsq(hess.get(), grad.get(), rcond=None)
+
+                #print (f'NEW {hess=} {grad=} {ni=} {x=}')
+                #print (f'{t5=}')
+                if ni == 0 or np.all(grad == 0):
+                    print ("EMPTY SET")
+                    return []
+                """
+                if np.allclose(ohess, hess, atol=1.e-5) and np.allclose(ograd, grad, atol=1.e-4):
+                    print ("MATCH")
+                else:
+                    if np.allclose(ox, x, atol=1.e-5):
+                        print ("MATCHX")
+                    print ("NO MATCH")
+                """
+
+                #step = cp.linalg.solve(hess, grad)
+                # Replace step = cp.linalg.solve(hess, grad)
+                """
+                res = cp.linalg.lstsq(hess, grad, rcond=1e-7)
+                print (f'{res=}')
+                step = res[0]
+                """
+
+                #if len(R_cpu) == 0:
+                if ni == 0 or np.all(grad == 0):
+                    print ("EMPTY SET")
+                    return []
+
+                """
+                gopt = [(step.get(), hess.get())]
+                gxicsum = 0
+                gicsum = 0
+                for gx, gic in gopt:
+                    print(f'{gx=} {gic=} {tr.catalog[0]=}')
+                    gxicsum = gxicsum + np.dot(gic, gx)
+                    gicsum = gicsum + gic
+                gxicsum = grad.get()
+                gxf,_,_,_ = np.linalg.lstsq(gicsum, gxicsum, rcond=None)
+                print ("gpu X_full: ",gxf)
+
+
+                xicsum = 0
+                icsum = 0
+                for cx,cic,_,_,_,_ in R_cpu:
+                    xicsum = xicsum + np.dot(cic, cx)
+                    icsum = icsum + cic
+                    print(f'{cx=} {cic=} {xicsum=} {icsum=} {tr.catalog[0]=}')
+                print (f'{icsum=} {xicsum=}')
+                cxf,_,_,_ = np.linalg.lstsq(icsum, xicsum, rcond=None)
+                print ("cpu X full: ", cxf)
+
+                if R_cpu is not None:
+                    try:
+                        assert(np.allclose(gicsum, icsum))
+                        print (f'{tr.catalog[0]=} icsum full match')
+                    except AssertionError as ex:
+                        print (f'{tr.catalog[0]=} icsum full does not match {gicsum=} {icsum=} {hess=}')
+                    try:
+                        assert(np.allclose(gxicsum, xicsum))
+                        print (f'{tr.catalog[0]=} xicsum full match')
+                    except AssertionError as ex:
+                        print (f'{tr.catalog[0]=} xicsum full does not match {gxicsum=} {xicsum=} {grad=} {step=}')
+                    try:
+                        assert(np.allclose(cxf, gxf))
+                        print (f'{tr.catalog[0]=} X full match')
+                    except AssertionError as ex:
+                        print (f'{tr.catalog[0]=} X full does not match {gxf=} {cxf=}')
+
+                """
+                tt[0] += time.time()-t
+                #tr.images = im
+                #tr.modelMasks = mm
+
+                #return [(step.get(), hess.get())]
+                return [(grad.get(), hess.get(), 1)]
+            elif isinstance(tr.catalog[0], PointSource):
+                tct[6] += 1
+            else:
+                tct[4] += 1
+
             print ("Running CPU version, frozen = ", tr.isParamFrozen('images'), "len = ", len(tr.catalog), " profile = ", isinstance(tr.catalog[0], ProfileGalaxy))
             #p = self.ps
             #self.ps = None
@@ -273,22 +1497,34 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
                 if self._gpumode == 1 or self._gpumode == 11:
                     return R_gpu
 
-        if self._gpumode == 2 or self._gpumode == 3 or self._gpumode == 12 or self._gpumode == 13:
+        if self._gpumode == 2 or self._gpumode == 3 or self._gpumode == 12 or self._gpumode == 13 or self._gpumode == 4:
+            import cupy as cp
+            import datetime
+            #Get free memory
             mempool = cp.get_default_memory_pool()
             mempool.free_all_blocks()
             free_mem, total_mem = cp.cuda.runtime.memGetInfo()
+            #Estimate memory needed with new helper method based on padded image sizes and nd
             nimages = len(tr.images)
             imsize = tr.images[0].data.size
             nd = tr.numberOfParams()+2
-            kmax = 4 #Use kmax 4 because many algorithms are now able to chunk memory
-            #Double size of 16 bit (complex 128) array x nimage x
-            #n derivs x kmax x imsize.  5D array in batch_mixture_profiles.py
-            #Dustin less_mem version
-            est_mem = nimages*imsize*nd*kmax*8 / 1.e+9
+            src = tr.catalog[0]
+            masks = [tr._getModelMaskFor(tim, src) for tim in tr.images]
+            if any(m is None for m in masks):
+                print (f"WARNING: One or more modelMasks is None; running CPU version.")
+                xout = super().getSingleImageUpdateDirections(tr, **kwargs)
+                return xout
+
+            assert(all([m is not None for m in masks]))
+            # Pixel positions
+            pxy = [tim.getWcs().positionToPixel(src.getPosition(), src)
+                   for tim in tr.images]
+            #New helper method predicts memory needed
+            est_mem = self.predict_fft_memory(tr, masks, pxy, nd)
             free_mem /= 1.e+9
             # 3.2 factor: NGC 3585 example
-            print (f'Estimated memory {est_mem} GB free memory {free_mem}')
-            
+            print (f'Estimated memory {est_mem} GB free memory {free_mem} for {nimages=} {imsize=} {nd=} at ', datetime.datetime.now(), "src = ", tr.catalog[0])
+
             if free_mem < est_mem:
                 try:
                     import datetime
@@ -296,6 +1532,8 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
                     #print("Warning: Estimated memory %.1f GB is greater than free memory %.1f GB; Running less-memory GPU mode instead!" % (est_mem / 1e9, free_mem / 1e9))
                     t = time.time()
                     R_gpu = self.gpuSingleImageUpdateDirectionsVectorized_less_mem(tr, **kwargs)
+                    mempool = cp.get_default_memory_pool()
+                    mempool.free_all_blocks()
                     tt[4] += time.time()-t
                     return R_gpu
                 except Exception as e:
@@ -304,22 +1542,10 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
                     traceback.print_exc()
                     mempool = cp.get_default_memory_pool()
                     mempool.free_all_blocks()
-                    
+
                 print('Running CPU version instead')
                 R_cpu = super().getSingleImageUpdateDirections(tr, **kwargs)
                 return R_cpu
-
-            #est_mem = nimages*imsize*nd*kmax*16
-            #import datetime
-            #print (f"Running VECTORIZED GPU code...", datetime.datetime.now(), "src = ", tr.catalog[0], f'Estimated mem {est_mem=} {free_mem=}')
-
-            #if free_mem < est_mem:
-            #    print (f"Warning: Estimated memory {est_mem} is greater than free memory {free_mem}; Running CPU mode instead!")
-            #    print (f"\t{nimages=} {imsize=} {nd=}")
-            #    R_gpuv = super().getSingleImageUpdateDirections(tr, **kwargs)
-            #    return R_gpuv
-            #else:
-                #print (f"Estimated memory {est_mem} is less than free memory {free_mem}")
 
             try:
                 #import datetime
@@ -331,45 +1557,49 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
                 #print ("Finished VECTORIZED code")
                 tt[2] += time.time()-t
                 tct[2] += 1
-                print ("GPU Vectorized time:", time.time()-t)
-                if self._gpumode == 2 or self._gpumode == 12:
+                #print ("GPU Vectorized time:", time.time()-t)
+                if self._gpumode == 2 or self._gpumode == 12 or self._gpumode == 4:
                     return R_gpuv
-            except AssertionError:
-                import traceback
-                print ("AssertionError in VECTORIZED GPU code:")
-                traceback.print_exc()
-                print ("Running CPU version instead...")
-                t = time.time()
-                R_gpuv = super().getSingleImageUpdateDirections(tr, **kwargs)
-                if self._gpumode == 2 or self._gpumode == 12:
-                    return R_gpuv
-            except cp.cuda.memory.OutOfMemoryError:
-                import traceback
-                free_mem, total_mem = cp.cuda.runtime.memGetInfo()
-                mempool = cp.get_default_memory_pool()
-                used_bytes = mempool.used_bytes()
-                tot_bytes = mempool.total_bytes()
-                print (f"Out of Memory for source "+str(tr.catalog[0]))
-                traceback.print_exc()
-                print (f'OOM Device {free_mem=} {total_mem=}; This mempool {used_bytes=} {tot_bytes=}')
-                print ("Running CPU version instead...")
-                mempool.free_all_blocks()
-                t = time.time()
-                R_gpuv = super().getSingleImageUpdateDirections(tr, **kwargs)
-                if self._gpumode == 2 or self._gpumode == 12:
-                    return R_gpuv
-            except Exception as ex:
-                import traceback
-                print('Exception in GPU Vectorized code: ', ex)
-                traceback.print_exc()
+            except Exception as e:
+                #New consolidated except
+                import cupy as cp
+                # 1. Capture the error string
+                err_msg = str(e).lower()
+                is_oom = "outofmemory" in err_msg or "out of memory" in err_msg
 
-                src = tr.catalog[0]
-                print('Source:', src)
-                print(repr(src))
-                print ("Running CPU version instead...")
+                # 2. Print immediately to stderr (bypasses buffering)
+                import sys
+                sys.stderr.write(f"\nCaught Exception in GPU code: {type(e).__name__}\n")
+                if is_oom:
+                    free_mem, total_mem = cp.cuda.runtime.memGetInfo()
+                    mempool = cp.get_default_memory_pool()
+                    used_bytes = mempool.used_bytes()
+                    tot_bytes = mempool.total_bytes()
+                    sys.stderr.write(f"Confirmed OOM for source: {tr.catalog[0]}\n")
+                    print (f'OOM Device {free_mem=} {total_mem=}; This mempool {used_bytes=} {tot_bytes=}')
+
+                sys.stderr.write(f"\n----Traceback below----\n")
+                import traceback
+                traceback.print_exc()
+                sys.stderr.flush()
+
+                # 3. Emergency Memory Release
+                try:
+                    import cupy as cp
+                    # Force drop image caches if they exist
+                    for tim in tr.images:
+                        if hasattr(tim, 'data_gpu'): tim.data_gpu = None
+                        if hasattr(tim, 'inverr_gpu'): tim.inverr_gpu = None
+                    cp.get_default_memory_pool().free_all_blocks()
+                except:
+                    pass
+
+                # 4. Final Fallback
+                print("Running CPU version instead... for source: "+str(tr.catalog[0]))
+                sys.stdout.flush()
                 t = time.time()
                 R_gpuv = super().getSingleImageUpdateDirections(tr, **kwargs)
-                if self._gpumode == 2 or self._gpumode == 12:
+                if self._gpumode == 2 or self._gpumode == 12 or self._gpumode == 4:
                     return R_gpuv
 
         if self._gpumode == 0 or self._gpumode == 3 or self._gpumode == 10 or self._gpumode == 13:
@@ -378,10 +1608,14 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
                 if not (tr.isParamFrozen('images') and (len(tr.catalog) == 1) and isinstance(tr.catalog[0], ProfileGalaxy)):
                     print ("Running CPU version, frozen = ", tr.isParamFrozen('images'), "len = ", len(tr.catalog), " profile = ", isinstance(tr.catalog[0], ProfileGalaxy))
                     tct[0] += 1
+                    #print ("TCT0", tct[0])
+                #else:
+                #    return []
                 t = time.time()
                 R_cpu = super().getSingleImageUpdateDirections(tr, **kwargs)
                 tt[3] += time.time()-t
                 tct[3] += 1
+                #print ("TCT3", tct[3])
                 #print ("CPU time", time.time()-t)
                 if self._gpumode == 0 or self._gpumode == 10:
                     return R_cpu
@@ -1182,8 +2416,11 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
         #print ("FSUM", Fsum.shape, "P", P.shape, P.max())
         #cp.savetxt('gfsum.txt', Fsum.ravel())
         #cp.savetxt('gp.txt', P.ravel())
-        G = cp.fft.irfft2(Fsum*P).astype(cp.float32)
-        del Fsum, P
+        # Multiply P into Fsum in-place to save one massive array allocation
+        Fsum *= P
+        del P # Free P immediately
+        G = cp.fft.irfft2(Fsum).astype(cp.float32)
+        del Fsum
         #Do Lanczos shift
         G = lanczos_shift_image_batch_gpu(G, img_params.mux, img_params.muy)
         #cp.savetxt('gg.txt', G.ravel())
@@ -2010,6 +3247,43 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
             cp.get_default_memory_pool().free_all_blocks()
         return G
 
+    def predict_fft_memory(self, tr, masks, pxy, max_nd):
+        # 1. Replicate the gpu_halfsize logic
+        # (Simplified version of your _getBatchImageParams logic)
+        px, py = np.array(pxy).T
+        extents = [mm.extent for mm in masks]
+        x0, x1, y0, y1 = np.asarray(extents).T
+        x0 = x0.astype(np.int32) 
+        x1 = x1.astype(np.int32) 
+        y0 = y0.astype(np.int32) 
+        y1 = y1.astype(np.int32)
+
+        # This is the "radius" that determines pH/pW
+        gpu_halfsize = np.max(([(x1-x0)/2, (y1-y0)/2,
+                                1+px-x0, 1+x1-px, 1+py-y0, 1+y1-py]), axis=0)
+
+        # 2. Calculate the Power-of-Two padding
+        radius_max = gpu_halfsize.max()
+        sz = 2**int(np.ceil(np.log2(radius_max * 2.)))
+
+        pH, pW = sz, sz
+        n_images = len(tr.images)
+
+        # 3. Calculate Actual Bytes
+        # Complex64 = 8 bytes, Float32 = 4 bytes
+        # Assume 8 arrays of complex64
+        # Assume 3 x arrays needed
+        est_mem = n_images * max_nd * pH * pW * 8. * 3 / (1024.**3)
+        print (f'{est_mem=} {n_images=} {max_nd=} {pH=} {pW=}')
+        #fsum_bytes = n_images * max_nd * pH * (pW // 2 + 1) * 8
+        #p_bytes = n_images * 1 * pH * (pW // 2 + 1) * 8
+        #g_bytes = n_images * max_nd * pH * pW * 4
+
+        # Total predicted for the FFT block (including a safety factor for IRFFT workspace)
+        #total_predicted_gb = (fsum_bytes + p_bytes + g_bytes * 2) / (1024**3)
+        #return total_predicted_gb, pH, pW
+        return est_mem
+
     def computeGalaxyModelsVectorized(self, img_params):
         # Note, this does *not* scale by *counts*, it produces unit-flux models
         t1 = time.time()
@@ -2028,8 +3302,12 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
         #P shape (Nimages, nw, nv)
         P = img_params.P[:,cp.newaxis,:,:]
         #print ("FSUM", Fsum.shape, "P", P.shape)
-        G = cp.fft.irfft2(Fsum*P).astype(cp.float32)
-        del Fsum, P
+        # Multiply P into Fsum in-place to save one massive array allocation
+        Fsum *= P
+        del P # Free P immediately
+        # Perform IRFFT on the modified Fsum
+        G = cp.fft.irfft2(Fsum).astype(cp.float32)
+        del Fsum
         #Do Lanczos shift
         G = lanczos_shift_image_batch_gpu(G, img_params.mux, img_params.muy)
         #cp.savetxt('vgg.txt', G.ravel())
@@ -2189,37 +3467,140 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
         alphaBest : float
             The optimal alpha (step size) found.
         """
-        if self._gpumode == 0:
-            return super().tryUpdates(tractor, X, alphas=alphas)
 
+        # 1. Fallback if GPU is disabled
+        if self._gpumode == 0 or self._gpumode == 4:
+            return super().tryUpdates(tractor, X, alphas=alphas, check_step=check_step)
+        #return super().tryUpdates(tractor, X, alphas=alphas)
+        #lp1 = super().tryUpdates(tractor, X, alphas=alphas)
+        #print (f'{lp1=}')
         t = time.time()
-        #mempool = cp.get_default_memory_pool()
-        #used_bytes = mempool.used_bytes()
-        #tot_bytes = mempool.total_bytes()
-        #print (f'{used_bytes=} {tot_bytes=}')
-        #mempool.free_all_blocks()
-        #used_bytes = mempool.used_bytes()
-        #tot_bytes = mempool.total_bytes()
-        #print (f'After free {used_bytes=} {tot_bytes=}')
-        #return super().tryUpdates(tractor, X, alphas=alphas, check_step=check_step)
         print ("GPU FACTORED TRY UPDATES")
+        print ("X", X.shape)
 
-        # Dustin's FIXME improvement ideas
-        # - pass in / cache initial logprob / model?
-        # - pass in / cache BatchPixelizedPSF ??
+        # 2. Check if we can use the PointSource GPU path
+        is_ptsrc = (len(tractor.catalog) == 1 and 
+                    isinstance(tractor.catalog[0], PointSource))
+        
+        # 3. Check if we can use the Galaxy GPU path
+        is_galaxy = (len(tractor.catalog) == 1 and 
+                     isinstance(tractor.catalog[0], ProfileGalaxy))
+
+        if tractor.isParamFrozen('images'):
+            if is_ptsrc:
+                # Use the new GPU Point Source Engine
+                # Check if we have a cached fitter for this source
+                if hasattr(self, 'current_fitter'):
+                    # Pass the work to the engine
+                    print ("Using new GPU PointSource Engine")
+
+                    tuc[0] += 1
+                    p0 = tractor.getParams()
+                    #t = time.time()
+                    #s_d, s_a = super().tryUpdates(tractor, X, alphas=alphas, check_step=check_step)
+                    #tu[1] += time.time()-t
+                    #tractor.setParams(p0)
+
+
+                    """
+                    #Estimate memory needed with new helper method based on padded image sizes and nd
+                    import cupy as cp
+                    import datetime
+                    # pixel position of the source in each image
+                    xy = [tim.getWcs().positionToPixel(src.pos) for tim in tractor.images]
+                    # pixel region to render
+                    masks = [tractor._getModelMaskFor(tim, src) for tim in tractor.images]
+
+                    #Get free memory
+                    mempool = cp.get_default_memory_pool()
+                    mempool.free_all_blocks()
+                    free_mem, total_mem = cp.cuda.runtime.memGetInfo()
+                    nd = tractor.numberOfParams()+2
+                    assert(all([m is not None for m in masks]))
+                    #New helper method predicts memory needed
+                    est_mem = self.predict_fft_memory(tractor, masks, xy, nd)
+                    free_mem /= 1.e+9
+                    print (f'TryUpdates PS: Estimated memory {est_mem} GB free memory {free_mem} for {Nimages=} {nd=} at ', datetime.datetime.now(), "src = ", tractor.catalog[0])
+                    use_less_mem = False
+                    if free_mem < est_mem:
+                        print(f"Warning: TryUpdates PS Estimated memory {est_mem} GB is greater than free memory {free_mem} GB; Running less-mem GPU mode instead!", datetime.datetime.now(), "src = ", tractor.catalog[0])
+                        #s_d, s_a = super().tryUpdates(tractor, X, alphas=alphas, check_step=check_step)
+                        #tu[5] += time.time()-t
+                        #return s_d, s_a
+                        use_less_mem = True
+                    """
+
+                    t = time.time()
+                    try:
+                        best_dlnp, best_alpha = self.current_fitter.tryUpdates_gpu(X, alphas, check_step=check_step)
+                        tu[0] += time.time()-t
+                    except Exception as ex:
+                        print ("Exception in TRY UPDATES GPU - running CPU version instead: "+str(ex))
+                        tu[0] += time.time()-t
+                        t = time.time()
+                        tractor.setParams(p0)
+                        s_d, s_a = super().tryUpdates(tractor, X, alphas=alphas, check_step=check_step)
+                        tu[1] += time.time()-t
+                        return s_d, s_a
+                    #import sys
+                    #sys.exit(0)
+                    # Clean up after the line search is done
+                    del self.current_fitter 
+                    #print (f'TU PS COMP {best_dlnp=} {s_d=} {best_alpha=} {s_a=}')
+                    #if s_a != best_alpha:
+                    #    print ("PS MISMATCH")
+                    #print (f'TU PS GPU {best_dlnp=} {best_alpha=}')
+                    #print (f'TU PS CPU {s_d=} {s_a=}')
+                    return best_dlnp, best_alpha
+                    #return s_d, s_a
+                t = time.time()
+                s_d, s_a = super().tryUpdates(tractor, X, alphas=alphas, check_step=check_step)
+                #return super().tryUpdates(tractor, X, alphas=alphas, check_step=check_step) 
+                tu[2] += time.time()-t
+                return s_d, s_a
+            
+        if not (is_galaxy and tractor.isParamFrozen('images')):
+            # 4. Fallback for everything else
+            print('Calling superclass tryUpdates')
+            t = time.time()
+            a = super().tryUpdates(tractor, X, alphas=alphas, check_step=check_step)
+            tuc[1] += 1
+            tu[3] += time.time()-t
+            return a
+            #return super().tryUpdates(tractor, X, alphas=alphas, check_step=check_step)
 
         if not ((len(tractor.catalog) == 1) and
                 isinstance(tractor.catalog[0], ProfileGalaxy) and
                 tractor.isParamFrozen('images')):
             print('Calling superclass tryUpdates')
-            return super().tryUpdates(tractor, X, alphas=alphas)
+            t = time.time()
+            #return super().tryUpdates(tractor, X, alphas=alphas)
+            s_d, s_a = super().tryUpdates(tractor, X, alphas=alphas, check_step=check_step)
+            tuc[2] += 1
+            tu[4] += time.time()-t
+            return s_d, s_a
+ 
 
-        print('number of images:', len(tractor.images))
+        # Dustin's FIXME improvement ideas
+        # - pass in / cache initial logprob / model?
+        # - pass in / cache BatchPixelizedPSF ??
+
+        #t = time.time()
+        #return super().tryUpdates(tractor, X, alphas=alphas)
+        tuc[3] += 1
+        #p0 = tractor.getParams()
+        #s_d, s_a = super().tryUpdates(tractor, X, alphas=alphas, check_step=check_step)
+        #tu[5] += time.time()-t
+        #return s_d, s_a
+        #tractor.setParams(p0)
+        t = time.time()
+
+        #print('number of images:', len(tractor.images))
         Nimages = len(tractor.images)
         src = tractor.catalog[0]
         steps = self.getParameterSteps(tractor, X, alphas)
-        print('number of steps (alphas) to try:', len(steps))
-        print ("Alphas", alphas)
+        #print('number of steps (alphas) to try:', len(steps))
+        #print ("Alphas", alphas, "STEPS", steps)
         if len(steps) == 0:
             self.last_step_hit_limit = True
             self.hit_limit = True
@@ -2237,6 +3618,33 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
         px, py = np.array(xy).T
         # pixel region to render
         masks = [tractor._getModelMaskFor(tim, src) for tim in tractor.images]
+        if any(m is None for m in masks):
+            print (f"TryUpdates WARNING: One or more modelMasks is None; running CPU version.")
+            s_d, s_a = super().tryUpdates(tractor, X, alphas=alphas, check_step=check_step)
+            tu[5] += time.time()-t
+            return s_d, s_a
+
+        #Estimate memory needed with new helper method based on padded image sizes and nd
+        import cupy as cp
+        import datetime
+        #Get free memory
+        mempool = cp.get_default_memory_pool()
+        mempool.free_all_blocks()
+        free_mem, total_mem = cp.cuda.runtime.memGetInfo()
+        nd = tractor.numberOfParams()+2
+        assert(all([m is not None for m in masks]))
+        #New helper method predicts memory needed
+        est_mem = self.predict_fft_memory(tractor, masks, xy, nd)
+        free_mem /= 1.e+9
+        print (f'TryUpdates: Estimated memory {est_mem} GB free memory {free_mem} for {Nimages=} {nd=} at ', datetime.datetime.now(), "src = ", tractor.catalog[0])
+        use_less_mem = False
+        if free_mem < est_mem:
+            print(f"Warning: TryUpdates Estimated memory {est_mem} GB is greater than free memory {free_mem} GB; Running less-mem GPU mode instead!", datetime.datetime.now(), "src = ", tractor.catalog[0])
+            #s_d, s_a = super().tryUpdates(tractor, X, alphas=alphas, check_step=check_step)
+            #tu[5] += time.time()-t
+            #return s_d, s_a
+            use_less_mem = True
+
         img_sky = [tim.getSky().getConstant() for tim in tractor.images]
         img_pix = [tim.getImage(use_gpu=True) for tim in tractor.images]
         img_ie  = [tim.getInvError(use_gpu=True) for tim in tractor.images]
@@ -2286,29 +3694,105 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
                 padded[:oldsize,:] = pro.mean
                 pro.mean = padded
 
-        img_params, cx,cy,pW,pH = self._getBatchImageParams(tractor, masks, xy)
+        if use_less_mem:
+            # Initialize the accumulator for all alpha steps
+            # This stays on the GPU so we don't transfer back and forth in the loop
+            total_chisq = cp.zeros(len(steps), dtype=cp.float32)
+            
+            # Pre-convert fluxes to GPU once (it's a small array)
+            # Shape: (nsteps, Nimages)
+            fluxes_gpu = cp.asarray(fluxes, dtype=cp.float32)
 
-        gals = self._getBatchGalaxyProfiles(profiles, masks, px, py, cx, cy, pW, pH,
-                                            fluxes[0], img_sky, img_pix, img_ie)
-        img_params.addBatchGalaxyProfiles(gals)
-        G = self.computeGalaxyModelsVectorized(img_params)
-        t = time.time()
-        assert(G.shape == (Nimages, len(steps), pH, pW))
-        mmpix = gals.mmpix
-        mmie = gals.mmie
-        fluxes = cp.asarray(fluxes, dtype=cp.float32)
-        sky = cp.asarray(img_sky, dtype=cp.float32)
-        #print ("MMPIX", mmpix.shape, mmie.shape, mmpix.max(), mmpix.sum())
-        #print ("FLUXES", fluxes.shape, fluxes)
-        #print ("SKY", sky.shape, sky)
+            tims = tractor.images
+            modelmasks = tractor.modelMasks
 
-        #print ("G", G.shape)
-        #chisq = cp.sum([((G[i_image] * fluxes[i_step, i_image] - mmpix[i_image]) * mmie[i_image])**2 for i_image in range(Nimages)])
-        chisq = self.calculate_chi2_cupy(G, fluxes, mmpix, mmie, sky) 
-        del G, img_params
-        mpool = cp.get_default_memory_pool()
-        mpool.free_all_blocks()
-        #print ("CHISQ", chisq.shape)
+            try:
+                for i in range(Nimages):
+                    # 1. Extract single-image data
+                    # We wrap these in lists so your existing Batch methods still work
+                    s_masks = [masks[i]]
+                    s_xy = [xy[i]]
+                    s_sky = [img_sky[i]]
+                    s_pix = [img_pix[i]]
+                    s_ie = [img_ie[i]]
+                    
+
+                    # 1. Create single-image profile data
+                    s_profiles = []
+                    for name, amix, step in profiles:
+                        #print (f'{amix.mean.shape=} {amix.amp.shape=} {amix.var.shape=}')
+                        #print (f'{type(amix)=}')
+                        #s_mean = amix.mean[i:i+1] # (1, Nd, K, D)
+                        #s_amp  = amix.amp[i:i+1]  # (1, Nd, K)
+                        s_var  = amix.var[i:i+1]  # (1, Nd, K, D, D)
+                        # amix.amp and amix.mean are usually shared (ng, ...) 
+                        # but if they were per-image, you'd slice them here too.
+                        #s_amix = BatchMixtureOfGaussians(s_amp, s_mean, s_var)
+                        s_amix = BatchMixtureOfGaussians(amix.amp, amix.mean, s_var, unbalanced=True)
+                        s_profiles.append((name, s_amix, step))
+
+                    tractor.images = [tims[i]]
+                    tractor.modelMasks = [modelmasks[i]]
+                    # 2. Setup single-image parameters and profiles
+                    # This keeps pH/pW consistent with the single image's needs
+                    img_params_i, cx_i, cy_i, pW_i, pH_i = self._getBatchImageParams(tractor, s_masks, s_xy)
+                    
+                    # Slicing fluxes_gpu for just this image: fluxes_gpu[:, i]
+                    gals_i = self._getBatchGalaxyProfiles(s_profiles, s_masks, px[i:i+1], py[i:i+1], 
+                                                          cx_i, cy_i, pW_i, pH_i,
+                                                          fluxes_gpu[0, i:i+1], s_sky, s_pix, s_ie)
+                    
+                    img_params_i.addBatchGalaxyProfiles(gals_i)
+                    
+                    # 3. Render and Calculate Chi2 for this image
+                    # G_i shape: (1, nsteps, pH_i, pW_i)
+                    G_i = self.computeGalaxyModelsVectorized(img_params_i)
+                    
+                    # Call a modified version of your chi2 function or inline it:
+                    # We sum over the image axes (2 and 3) and the single image axis (0)
+                    # to get a (nsteps,) result to add to total_chisq.
+                    total_chisq += self.calculate_chi2_cupy(G_i, fluxes_gpu[:, [i]], 
+                                                            gals_i.mmpix, gals_i.mmie, 
+                                                            cp.asarray(s_sky))
+
+                    # 4. CRITICAL: Clear the deck for the next image
+                    del G_i, img_params_i, gals_i, s_pix, s_ie
+                    cp.get_default_memory_pool().free_all_blocks()
+
+            finally:
+                # Always restore state even if the loop fails
+                tractor.images = tims
+                tractor.modelMasks = modelmasks
+            # Move final result back to CPU for the logprob logic
+            chisq = total_chisq
+        else:
+            img_params, cx,cy,pW,pH = self._getBatchImageParams(tractor, masks, xy)
+
+            gals = self._getBatchGalaxyProfiles(profiles, masks, px, py, cx, cy, pW, pH,
+                                                fluxes[0], img_sky, img_pix, img_ie)
+            img_params.addBatchGalaxyProfiles(gals)
+            if img_params.ffts is None:
+                print ("Warning> img_params.ffts is None!  Calling superclass tryUpdates (on CPU)")
+                #print (f'TU Z2 0 {s_d=} 0 {s_a=}')
+                tu[6] += time.time()-t
+                return super().tryUpdates(tractor, X, alphas=alphas, check_step=check_step)
+            G = self.computeGalaxyModelsVectorized(img_params)
+            assert(G.shape == (Nimages, len(steps), pH, pW))
+            mmpix = gals.mmpix
+            mmie = gals.mmie
+            fluxes = cp.asarray(fluxes, dtype=cp.float32)
+            sky = cp.asarray(img_sky, dtype=cp.float32)
+            #print ("MMPIX", mmpix.shape, mmie.shape, mmpix.max(), mmpix.sum())
+            #print ("FLUXES", fluxes.shape, fluxes)
+            #print ("SKY", sky.shape, sky)
+
+            #print ("G", G.shape)
+            #chisq = cp.sum([((G[i_image] * fluxes[i_step, i_image] - mmpix[i_image]) * mmie[i_image])**2 for i_image in range(Nimages)])
+            chisq = self.calculate_chi2_cupy(G, fluxes, mmpix, mmie, sky) 
+            del G, img_params
+            mpool = cp.get_default_memory_pool()
+            mpool.free_all_blocks()
+            #print ("CHISQ", chisq.shape)
 
         #print ("PRIOR", logpriors)
         logprob = np.array(logpriors)-0.5*chisq.get()
@@ -2356,14 +3840,22 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
         tt[6] += time.time()-t
         if max_idx == len(logprob)-1:
             print ("Best is previous")
+            #print (f'TU Z1 0 {s_d=} 0 {s_a=}')
+            tu[6] += time.time()-t
             return (0., 0.)
 
         lp_best = logprob[max_idx]
         lp_last = logprob[-1]
+        alpha = steps[max_idx][0] #get alpha from steps not array of alphas!
         if lp_best > lp_last:
             # Best we've found so far -- accept this step!
             self.last_step_hit_limit = hit_limit
-        return (lp_best-lp_last, alphas[max_idx])
+        tu[6] += time.time()-t
+        #g_d = lp_best-lp_last
+        #print (f'TU G {g_d=} {s_d=} {alpha=} {s_a=}')
+        #if s_a != alpha:
+        #    print ("GAL MISMATCH")
+        return (lp_best-lp_last, alpha)
 
 
     def calculate_chi2_cupy(self, G, fluxes, mmpix, mmie, sky):
@@ -2443,6 +3935,7 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
         imgH, imgW = np.array([tim.shape for tim in tr.images]).T
         psfH, psfW = np.array([psf.shape for psf in psfs]).T
         x0, x1, y0, y1 = np.asarray(extents).T
+        #print (f'{x0=} {x0.dtype=}')
         """
         if np.any(px < 0):
             print (f"Warning: {px=} is outside of image")
@@ -2472,6 +3965,51 @@ class GPUFriendlyOptimizer(FactoredDenseOptimizer):
 
         img_params = BatchImageParams(P, v, w, batch_psf.psf_mogs)
         return img_params, cx,cy, pH,pW
+
+    def _getBatchPointSourceProfiles(self, derivs, masks, px, py, cx, cy, pW, pH,
+                                     img_counts, img_sky, img_pix, img_ie):
+        Nimages = len(img_counts)
+        mx0, mx1, my0, my1, mh, mw = np.array([(mm.x0, mm.x1, mm.y0, mm.y1)+mm.shape for mm in masks]).T
+        counts = cp.asarray(img_counts, dtype=cp.float32)
+
+        extents = [mm.extent for mm in masks]
+        x0, x1, y0, y1 = np.asarray(extents).T
+
+        # sub-pixel shift we have to do at the end...
+        dx = px - cx
+        dy = py - cy
+        mux = dx - x0
+        muy = dy - y0
+        sx = mux.round().astype(np.int32)
+        sy = muy.round().astype(np.int32)
+        # the subpixel portion will be handled with a Lanczos interpolation
+        mux -= sx
+        muy -= sy
+        dxi = cp.asarray(x0+sx)
+        dyi = cp.asarray(y0+sy)
+        assert(np.abs(mux).max() <= 0.5)
+        assert(np.abs(muy).max() <= 0.5)
+
+        # Embed pix and ie in images the same size as pW,pH.
+        padpix = cp.zeros((Nimages, pH,pW), cp.float32)
+        padie  = cp.zeros((Nimages, pH,pW), cp.float32)
+        assert(np.all(sy <= 0) and np.all(sx <= 0))
+
+        x_delta = np.ones(mx0.shape, np.int32)
+        y_delta = np.ones(my0.shape, np.int32)
+        x_delta[mx0 == 0] = 0
+        y_delta[my0 == 0] = 0
+        x_delta[sx == 0] = 0
+        y_delta[sy == 0] = 0
+        for i, pix in enumerate(img_pix):
+            padpix[i, -sy[i]-y_delta[i]:-sy[i]+mh[i], -sx[i]-x_delta[i]:-sx[i]+mw[i]] = pix[my0[i]-y_delta[i]:my1[i], mx0[i]-x_delta[i]:mx1[i]]
+        for i, ie in enumerate(img_ie):
+            padie[i, -sy[i]-y_delta[i]:-sy[i]+mh[i], -sx[i]-x_delta[i]:-sx[i]+mw[i]] = ie[my0[i]-y_delta[i]:my1[i], mx0[i]-x_delta[i]:mx1[i]]
+        roi = cp.asarray([-sx, -sy, mw, mh]).T
+        mmpix = cp.asarray(padpix)
+        mmie = cp.asarray(padie)
+        sky = cp.asarray(img_sky, dtype=cp.float32)
+
 
     def _getBatchGalaxyProfiles(self, amixes_gpu, masks, px, py, cx, cy, pW, pH,
                                 img_counts, img_sky, img_pix, img_ie):

--- a/tractor/gpu_lsqr_optimizer.py
+++ b/tractor/gpu_lsqr_optimizer.py
@@ -11,6 +11,12 @@ from tractor.utils import listmax
 from tractor.lsqr_optimizer import LsqrOptimizer
 import time
 
+gsub = np.zeros(10)
+g2 = np.zeros(8)
+g3 = np.zeros(8)
+gsub2 = np.zeros(6)
+gsub3 = np.zeros(8)
+
 def listmax_gpu(X, default=0):
     # X is expected to be a list of CuPy arrays
     mx_vals = []
@@ -24,13 +30,397 @@ def listmax_gpu(X, default=0):
     return cp.max(cp.array(mx_vals)).item() # .item() to get Python scalar if needed
 
 class GPULsqrOptimizer(LsqrOptimizer):
+    _gpumode = 4
+
     def getUpdateDirection(self, tractor, allderivs, damp=0., priors=True,
                            scale_columns=True, scales_only=False,
                            chiImages=None, variance=False,
                            shared_params=True,
                            get_A_matrix=False):
-        #print ("GPULsqrOptimizer!")
+        if self._gpumode == 4:
+            print ("GPUMODE 4")
+            X1 = self.getUpdateDirection_orig(tractor, allderivs, damp, priors,
+                                        scale_columns, scales_only,
+                                        chiImages, variance,
+                                        shared_params,
+                                        get_A_matrix)
+            print ("GLTimes: NEW ", gsub[0], "OLD ",gsub[5])
+            return X1
+        try:
+            X1 = self.getUpdateDirection_new(tractor, allderivs, damp, priors,
+                                        scale_columns, scales_only,
+                                        chiImages, variance,
+                                        shared_params,
+                                        get_A_matrix)
+
+        except Exception as ex:
+            print ("GPULsqrOptimizer Exception: "+str(ex)+"; Running previous version instead.")
+            X1 = self.getUpdateDirection_orig(tractor, allderivs, damp, priors,
+                                        scale_columns, scales_only,
+                                        chiImages, variance,
+                                        shared_params,
+                                        get_A_matrix)
+        #print (f'{gsub=}\n{g2=}\n{gsub2=}\n{g3=}\n{gsub3=}')
+        print ("GLTimes: NEW ", gsub[0], "OLD ",gsub[5])
+        return X1
+
+    def getUpdateDirection_new(self, tractor, allderivs, damp=0., priors=True,
+                           scale_columns=True, scales_only=False,
+                           chiImages=None, variance=False,
+                           shared_params=True,
+                           get_A_matrix=False):
+        print ("GPULsqrOptimizerBatch!")
         #print ("TRACTOR", type(tractor), tractor.getParams, tractor.setParams)
+        t = time.time()
+
+        if shared_params:
+            # Assuming tractor.getParams() now returns CuPy arrays
+            p0 = tractor.getParams()
+            tractor.setParams(np.arange(len(p0))) # Using cp.arange directly
+            p1 = tractor.getParams()
+            tractor.setParams(p0) # Restore original params
+
+            # np.unique replaced by cp.unique, returns CuPy arrays
+            U, I = np.unique(p1, return_inverse=True)
+            logverb(len(p0), 'params;', len(U), 'unique')
+            paramindexmap = I # I is already a CuPy array
+
+        # Build the sparse matrix of derivatives:
+        sprows = [] # Will hold CuPy arrays of row indices
+        spcols = [] # Will hold CuPy arrays of column indices (or just ints if single col)
+        spvals = [] # Will hold CuPy arrays of values
+
+        # Keep track of row offsets for each image.
+        imgoffs = {}
+        nextrow = 0
+        skyVal = None
+        for param in allderivs:
+            for deriv, img in param:
+                if skyVal is None:
+                    skyVal = deriv.getImage()[0,0]
+                if img in imgoffs:
+                    continue
+                imgoffs[img] = nextrow
+                nextrow += img.numberOfPixels()
+        Nrows = nextrow
+        del nextrow
+        Ncols = len(allderivs)
+        if variance:
+            var = cp.zeros(Ncols, cp.float32)
+
+        colscales = cp.ones(Ncols)
+
+        t1 = time.time()
+        active_tims = list(imgoffs.keys())
+        if len(active_tims) == 0:
+            print ("GPULsqrOptimizer> Empty list of tims")
+            return []
+        # PRE-COMPUTE: These are our "Reference Tensors"
+        ie3d = tractor.get_3d_stack_InvErrors(active_tims)
+        Nsky = len(active_tims)
+        # Get dimensions from the padded ie3d
+        depth, max_h, max_w = ie3d.shape
+        # Initialize the row map on the GPU
+        row_map3d = cp.zeros((depth, max_h, max_w), dtype=cp.int32)
+
+        for i, tim in enumerate(active_tims):
+            h, w = tim.shape
+            row0 = imgoffs[tim]
+            # Create a 2D grid of row indices for this specific image
+            # row0, row0+1, row0+2 ... row0 + (h*w - 1)
+            img_rows = cp.arange(row0, row0 + (h * w), dtype=cp.int32).reshape(h, w)
+            # Inject it into the 3D stack
+            row_map3d[i, :h, :w] = img_rows
+
+        # Create a global mask of where InvErr is strictly positive
+        # This captures both image boundaries and bad-pixel masks
+        global_nonzero_mask = ie3d > 0
+
+        # Compress ie3d and row_map3d into 1D 'Super-Vectors'
+        # This removes 99% of the zeros before the loops start
+        ie_vector = ie3d[global_nonzero_mask]
+        master_rows = row_map3d[global_nonzero_mask]
+
+        # Pre-calculate offsets in the compressed vector for each image
+        compressed_offsets = []
+        curr = 0
+        for i in range(len(active_tims)):
+            # count non-zero pixels in this specific image slice
+            n_valid = int(cp.sum(global_nonzero_mask[i]))
+            compressed_offsets.append((curr, curr + n_valid))
+            curr += n_valid
+
+        g2[0] += time.time()-t1
+        t1 = time.time()
+        # 2. SKY FITTING
+        for col in range(Nsky):
+            start, end = compressed_offsets[col]
+
+            # These are already non-zero!
+            vals = ie_vector[start:end] * skyVal
+            rows = master_rows[start:end]
+
+            # Scale is now a simple norm of a much smaller vector
+            scale = cp.sqrt(cp.sum(vals**2))
+            colscales[col] = scale
+
+            if not scales_only and scale > 0:
+                spvals.append(vals / scale if scale_columns else vals)
+                sprows.append(rows)
+                spcols.append(cp.full(vals.size, col, dtype=cp.int32))
+        g2[1] += time.time()-t1
+
+        # 3. POINT SOURCE PHASE (Remaining Columns)
+        FACTOR = 1.e-10
+        for col in range(Nsky, len(allderivs)):
+            col_vals = []
+            col_rows = []
+
+            for deriv, img in allderivs[col]:
+                # 1. CPU-side extraction (Fast)
+                t2 = time.time()
+                d_img = deriv.patch
+                ie_patch = img.getInvError(use_gpu=False)[deriv.getSlice(img)]
+
+                # 2. CPU Math
+                v_flat = (d_img * ie_patch).ravel()
+                gsub2[0] += time.time()-t2
+                t2 = time.time()
+
+                # 3. Filtering (Masking on CPU is faster for < 10k pixels)
+                mx = np.abs(v_flat).max()
+                if mx == 0: continue
+
+                m = (np.abs(v_flat) > (FACTOR * mx))
+
+                # 4. Row Mapping (Original Logic)
+                row0 = imgoffs[img]
+                # pix is the 1D offset of every pixel in the patch
+                pix = deriv.getPixelIndices(img).ravel()
+                gsub2[1] += time.time()-t2
+                t2 = time.time()
+
+                # Apply the same mask 'm' to both values and pixel indices
+                col_vals.append(v_flat[m])
+                col_rows.append(row0 + pix[m])
+                gsub2[2] += time.time()-t2
+
+            if not col_vals:
+                colscales[col] = 0.0
+                continue
+
+            # 5. Move to GPU in bulk
+            # Moving one concatenated array is MUCH faster than many small ones
+            t2 = time.time()
+            vals_cpu = np.concatenate(col_vals)
+            rows_cpu = np.concatenate(col_rows)
+            gsub2[3] += time.time()-t2
+
+            t2 = time.time()
+            vals = cp.asarray(vals_cpu)
+            rows = cp.asarray(rows_cpu)
+            gsub2[4] += time.time()-t2
+
+            #Scaling
+            scale = cp.sqrt(cp.sum(vals**2))
+            colscales[col] = scale
+
+            if scales_only or scale == 0:
+                continue
+
+            # 6. Append
+            spvals.append(vals / scale if scale_columns else vals)
+            sprows.append(rows)
+            spcols.append(cp.full(vals.size, col, dtype=cp.int32))
+
+        g2[3] += time.time()-t1
+
+        if scales_only:
+            return colscales.get()
+
+        t1 = time.time()
+        im3d = tractor.get_3d_stack_Data(active_tims)
+        gsub[2] += time.time()-t1
+
+        t1 = time.time()
+        b = None
+        if priors:
+            # Assuming tractor.getLogPriorDerivatives() now returns Python lists/NumPy arrays
+            X_prior = tractor.getLogPriorDerivatives()
+            if X_prior is not None:
+                # Unpack lists/NumPy arrays from the CPU
+                rA, cA, vA, pb, mub = X_prior
+
+                # sprows gets a list of CuPy arrays. The addition Nrows to a NumPy array is fine
+                # as the result is still a NumPy array. These are then stored as lists within sprows.
+                # If rA contains lists of ints, np.array() converts them.
+                # rA elements are typically 1D NumPy arrays, so addition is element-wise.
+                # Then append these NumPy arrays to the list sprows.
+                sprows.extend([cp.array(rij) + Nrows for rij in rA])
+
+                # cA is a List
+                spcols.append(cp.asarray(cA, dtype=cp.int32))
+
+                if scale_columns:
+                    # Perform division using NumPy arrays and Python lists
+                    # colscales is a CuPy array, but its elements can be accessed on CPU for zip.
+                    # Or better, convert colscales to NumPy for this small op if many prior terms.
+                    # For a few terms, accessing elements of colscales (which is on GPU) via indexing
+                    # will implicitly transfer small scalars, which is generally acceptable.
+                    # Let's explicitly bring colscales to CPU if we're doing list comprehension with it.
+                    colscales_cpu = colscales.get()
+                    scaled_vA = [v_val / colscales_cpu[c_idx] for v_val, c_idx in zip(vA, cA)]
+                    spvals.extend(cp.asarray(scaled_vA)) #Convert list to cp array
+                else:
+                    spvals.extend(cp.asarray([vA])) #Convert list to cp array
+
+                oldnrows = Nrows
+                # Call the NumPy-aware listmax
+                nr = listmax(rA if rA else [], -1) + 1
+                Nrows += nr
+                logverb('Nrows was %i, added %i rows of priors => %i' %
+                                (oldnrows, nr, Nrows))
+
+                # Now, when building 'b', we convert prior values to CuPy
+                b = cp.zeros(Nrows, dtype=(np.array(pb)).dtype) # Use dtype from pb
+                b[oldnrows:] = cp.asarray(np.hstack(pb)) # Ensure pb is hstacked as NumPy before CuPy conversion
+
+        if len(spcols) == 0:
+            logverb("len(spcols) == 0")
+            return []
+
+        if b is None:
+            b = cp.zeros(Nrows)
+            #print ("NROWS",Nrows, Ncols)
+
+        # Build chi vector 'b'
+        # Assuming tractor.getChiImage() returns CuPy arrays
+        # And if chiImages is provided, it contains CuPy arrays
+        gsub[1] += time.time()-t1
+        if chiImages is not None:
+            #TODO: update so that getImages is not called
+            chimap = {img: chi for img, chi in zip(tractor.getImagesGPU(), chiImages)}
+        else:
+            chimap = {}
+
+        t1 = time.time()
+        chi3d = tractor.get_3d_stack_Chi(active_tims, ie=ie3d, im=im3d)
+        assert(cp.all(cp.isfinite(chi3d)))
+        g2[4] += time.time()-t1
+        t1 = time.time()
+        i = 0
+        #Loop over chi3d
+        for img, row0 in imgoffs.items():
+            (h, w) = active_tims[i].shape
+            NP = h*w
+            b[row0: row0 + NP] =  chi3d[i][:h,:w].ravel()
+            i += 1
+        g2[7] += time.time()-t1
+        t1 = time.time()
+        spvals_cp = cp.concatenate(spvals)
+        sprows_cp = cp.concatenate(sprows)
+        spcols_cp = cp.concatenate(spcols)
+        g2[5] += time.time()-t1
+        del sprows
+        del spvals
+        del spcols
+        if not cp.all(cp.isfinite(spvals_cp)):
+            print('Warning: infinite derivatives; bailing out')
+            return None
+        assert(len(sprows_cp) == len(spcols_cp))
+
+        if isverbose:
+            logverb('  Number of sparse matrix elements:', len(sprows_cp))
+            urows = cp.unique(sprows_cp)
+            ucols = cp.unique(spcols_cp)
+            logverb('  Unique rows (pixels):', len(urows))
+            logverb('  Unique columns (params):', len(ucols))
+            if len(urows) == 0 or len(ucols) == 0:
+                return []
+            logverb('  Max row:', urows[-1].item()) # .item() for logging
+            logverb('  Max column:', ucols[-1].item()) # .item() for logging
+            logverb('  Sparsity factor (possible elements / filled elements):',
+                    float(len(urows) * len(ucols)) / float(len(sprows_cp)))
+
+        t1 = time.time()
+        # Build sparse matrix A
+        A = cpxr_matrix((spvals_cp, (sprows_cp, spcols_cp)), shape=(Nrows, Ncols))
+        g2[6] += time.time()-t1
+
+        # Remove the complex damping augmentation logic, as lsmr handles it internally
+        # A_lsqr = A # These will now just be A and b directly
+        # b_lsqr = b
+
+        t1 = time.time()
+        cplsmr_opts = dict(damp=damp) # Now damp is a valid argument for lsmr!
+        # You can add other parameters here if you need them later, e.g.,
+        # cplsmr_opts['atol'] = 1e-6
+        # cplsmr_opts['btol'] = 1e-6
+        # cplsmr_opts['conlim'] = 1e8
+
+        logverb('LSMR: %i cols (%i unique), %i elements' % # Changed log message
+                (Ncols, len(ucols), len(spvals_cp) - 1))
+
+        bail = False
+        try:
+            # CHANGE THIS LINE: Call cplsmr instead of cplsqr
+            (X, istop, niters, r1norm, arnorm, anorm, acond, xnorm) = cplsmr(A, b, **cplsmr_opts)
+        except cp.cuda.runtime.CUDARuntimeError as e:
+            print(f'CuPy CUDA Runtime Error caught: {e}. Returning zero.')
+            bail = True
+        except Exception as e:
+            print(f'General error caught: {e}. Returning zero.')
+            bail = True
+
+        del A
+        del b
+        gsub[3] += time.time()-t1
+        # No need to delete A_augmented or b_augmented since we're using lsmr
+        if bail:
+            if shared_params:
+                return cp.zeros(len(paramindexmap)).get()
+            return cp.zeros(len(allderivs)).get()
+        logverb('scaled  X=', X)
+
+        if shared_params:
+            X = X[paramindexmap]
+
+        if scale_columns:
+            positive_colscales_mask = colscales > 0
+            X[positive_colscales_mask] /= colscales[positive_colscales_mask]
+        logverb('  X=', X)
+
+        gsub[0] += time.time()-t
+        #print (f'{gsub=}\n{g2=}\n{gsub2=}\n{g3=}\n{gsub3=}')
+        if variance:
+            if shared_params:
+                var = var[paramindexmap]
+            # Ensure variance is not zero to avoid division by zero
+            var_reciprocal = cp.zeros_like(var)
+            non_zero_mask = var > 0
+            var_reciprocal[non_zero_mask] = 1. / var[non_zero_mask]
+            # lsmr doesn't return lsqrvar directly like scipy's lsqr
+            # If you need this, it needs to be calculated after the solution X
+            # based on (A'A + damp^2*I)^{-1}. This is typically the diagonal of the inverse
+            # of the normal equations matrix. It's not trivial to get from LSMR directly.
+            # You might need to compute it explicitly if calc_var is True and you need this.
+            # For now, I'll return None for lsqrvar to match what lsmr might imply.
+            #return X, var_reciprocal
+            return X.get(), var_reciprocal.get() # lsmr doesn't return calc_var directly
+                                                 # You might need to re-think what var_reciprocal means here
+                                                 # if it was intended to be derived from lsqrvar.
+
+        return X.get()
+
+
+    def getUpdateDirection_orig(self, tractor, allderivs, damp=0., priors=True,
+                           scale_columns=True, scales_only=False,
+                           chiImages=None, variance=False,
+                           shared_params=True,
+                           get_A_matrix=False):
+        print ("GPULsqrOptimizer!")
+        #print ("TRACTOR", type(tractor), tractor.getParams, tractor.setParams)
+        t = time.time()
 
         if shared_params:
             # Assuming tractor.getParams() now returns CuPy arrays
@@ -64,12 +454,16 @@ class GPULsqrOptimizer(LsqrOptimizer):
         if variance:
             var = cp.zeros(Ncols, cp.float32)
 
+        t1 = time.time()
         colscales = cp.ones(Ncols)
         for col, param in enumerate(allderivs):
             RR = []
             VV = []
             WW = []
-            for (deriv, img) in param:
+            t2 = time.time()
+            #print (f'{col=} {param=}')
+            for deriv, img in param:
+                #print (f'{deriv=} {img=}')
                 # Use CPU for smaller arrays sizes, copy to GPU after accumulation 
                 inverrs = img.getInvError(use_gpu=False) 
                 (H, W) = img.shape
@@ -117,6 +511,14 @@ class GPULsqrOptimizer(LsqrOptimizer):
                 VV.append(vals)
                 WW.append(w)
 
+            if len(param) == 1:
+                gsub3[0] += time.time()-t2
+                gsub3[6] += 1
+            else:
+                gsub3[5] += time.time()-t2
+                gsub3[7] += 1
+            gsub3[1] += time.time()-t2
+            t2 = time.time()
             if len(VV) == 0:
                 continue
 
@@ -129,7 +531,9 @@ class GPULsqrOptimizer(LsqrOptimizer):
             VV = cp.asarray(VV)
             WW = cp.asarray(WW)
             vals = VV * WW
+            gsub3[2] += time.time()-t2
 
+            t2 = time.time()
             if len(vals) == 0:
                 print ("Error: VALS LEN 0")   
                 continue
@@ -147,6 +551,7 @@ class GPULsqrOptimizer(LsqrOptimizer):
             
             scale = cp.sqrt(cp.dot(vals, vals))
             colscales[col] = scale
+            gsub3[3] += time.time()-t2
 
             if scales_only:
                 continue
@@ -164,9 +569,11 @@ class GPULsqrOptimizer(LsqrOptimizer):
             else:
                 spvals.append(vals)
 
+        g3[0] += time.time()-t1
         if scales_only:
             return colscales.get()
 
+        t1 = time.time()
         b = None
         if priors:
             # Assuming tractor.getLogPriorDerivatives() now returns Python lists/NumPy arrays
@@ -230,22 +637,30 @@ class GPULsqrOptimizer(LsqrOptimizer):
         # Build chi vector 'b'
         # Assuming tractor.getChiImage() returns CuPy arrays
         # And if chiImages is provided, it contains CuPy arrays
+        gsub[6] += time.time()-t1
         if chiImages is not None:
             #TODO: update so that getImages is not called
             chimap = {img: chi for img, chi in zip(tractor.getImagesGPU(), chiImages)}
         else:
             chimap = {}
 
+        t1 = time.time()
         for img, row0 in imgoffs.items():
+            t2 = time.time()
             chi = chimap.get(img, None)
             if chi is None:
                 # Assuming tractor.getChiImage() returns CuPy array
                 chi = tractor.getChiImageGPU(img=img)
+            gsub3[4] += time.time()-t2
+            #print (f'{i=} chi {chi.shape=} {type(chi)=} {chi.max()=} {chi.sum()=} {chi3d[i].shape=} {chi3d[i].max()=} {chi3d[i].sum()=}')
+            #print (cp.where(chi == chi.max()), cp.where(chi3d[i] == chi3d[i].max()))
             chi_ravelled = chi.ravel()
             NP = len(chi_ravelled)
             assert(cp.all(b[row0: row0 + NP] == 0))
             assert(cp.all(cp.isfinite(chi_ravelled)))
             b[row0: row0 + NP] = chi_ravelled
+        g3[4] += time.time()-t1
+        t1 = time.time()
 
         spvals_cp = cp.hstack(spvals)
         if not cp.all(cp.isfinite(spvals_cp)):
@@ -282,13 +697,24 @@ class GPULsqrOptimizer(LsqrOptimizer):
                 float(len(urows) * len(ucols)) / float(len(sprows_cp)))
 
 
+        g3[5] += time.time()-t1
+        #print (f'{spvals_cp2.shape=} {sprows_cp2.shape=} {spcols_cp2.shape=} {Nrows=} {Ncols=}')
+        #print (f'{spvals_cp.shape=} {sprows_cp.shape=} {spcols_cp.shape=}')
+        #try:
+        #    print ("AC ",cp.allclose(spvals_cp, spvals_cp2), cp.allclose(sprows_cp, sprows_cp2), cp.allclose(b, b2))
+        #except Exception as ex:
+        #    print ("AC Err", spvals_cp.max(), spvals_cp2.max())
+        t1 = time.time()
         # Build sparse matrix A
         A = cpxr_matrix((spvals_cp, (sprows_cp, spcols_cp)), shape=(Nrows, Ncols))
+        g3[6] += time.time()-t1
+        #print (f'{A.shape=} {A2.shape=} {A.max()=} {A2.max()=}')
 
         # Remove the complex damping augmentation logic, as lsmr handles it internally
         # A_lsqr = A # These will now just be A and b directly
         # b_lsqr = b
 
+        t1 = time.time()
         cplsmr_opts = dict(damp=damp) # Now damp is a valid argument for lsmr!
         # You can add other parameters here if you need them later, e.g.,
         # cplsmr_opts['atol'] = 1e-6
@@ -311,8 +737,9 @@ class GPULsqrOptimizer(LsqrOptimizer):
 
         del A
         del b
+        gsub[8] += time.time()-t1
         # No need to delete A_augmented or b_augmented since we're using lsmr
-
+        #print (f'{X=} {X2=}', cp.allclose(X, X2))
         if bail:
             if shared_params:
                 return cp.zeros(len(paramindexmap)).get()
@@ -328,6 +755,7 @@ class GPULsqrOptimizer(LsqrOptimizer):
             X[positive_colscales_mask] /= colscales[positive_colscales_mask]
         logverb('  X=', X)
 
+        gsub[5] += time.time()-t
         if variance:
             if shared_params:
                 var = var[paramindexmap]

--- a/tractor/image.py
+++ b/tractor/image.py
@@ -177,7 +177,9 @@ class Image(MultiParams):
         self.inverr = inverr
         self.inverr_gpu = None #Clear GPU, will be copied again on demand
 
-    def getInvvar(self):
+    def getInvvar(self, use_gpu=False):
+        if use_gpu:
+            return self.getInvError(use_gpu=True)**2
         return self.inverr**2
 
     def setInvvar(self, iv):

--- a/tractor/lsqr_optimizer.py
+++ b/tractor/lsqr_optimizer.py
@@ -7,13 +7,16 @@ from tractor.utils import listmax
 import time
 import os
 
-lt = np.zeros(6)
+lt = np.zeros(7)
 lct = np.zeros(2, dtype=np.int32)
 
 def printTiming():
     print ("LTimes [getLin tryUpdates optimize 0 getUpdateDir derivs]:", lt, "LCT", lct)
 
 class LsqrOptimizer(Optimizer):
+
+    def printLsqrTiming():
+        print ("LTimes [getLin tryUpdates optimize 0 getUpdateDir derivs]:", lt, "LCT", lct)
 
     def _optimize_forcedphot_core(
             self, tractor,
@@ -283,6 +286,7 @@ class LsqrOptimizer(Optimizer):
         #       print('patch mean', np.mean(p.patch))
         #logverb('Finding optimal update direction...')
         #t0 = Time()
+        t = time.time()
         X = self.getUpdateDirection(tractor, allderivs, damp=damp,
                                     priors=priors,
                                     scale_columns=scale_columns,
@@ -290,6 +294,8 @@ class LsqrOptimizer(Optimizer):
                                     variance=variance)
 
         #print (f"LSQR {X=}")
+        lt[6] += time.time()-t
+        #print ("LTimes2:",lt)
         return X
 
     def optimize(self, tractor, alphas=None, damp=0, priors=True,
@@ -301,6 +307,7 @@ class LsqrOptimizer(Optimizer):
                    scale_columns=scale_columns, shared_params=shared_params)
         t = time.time()
         X = self.getLinearUpdateDirection(tractor, **kwa)
+        lt[0] += time.time()-t
         if X is None:
             # Failure
             return (0., None, 0.)
@@ -318,6 +325,7 @@ class LsqrOptimizer(Optimizer):
         #logverb('X: len', len(X), '; non-zero entries:', np.count_nonzero(X))
         logverb('Finding optimal step size...')
         #t0 = Time()
+        t = time.time()
         lct[0] += 1
         (dlogprob, alpha) = self.tryUpdates(tractor, X, alphas=alphas, check_step=check_step)
         #print (f"LSQR TryUpdates Results: {dlogprob=}, {alpha=}")
@@ -329,13 +337,14 @@ class LsqrOptimizer(Optimizer):
         #logverb('  Topt  ', topt)
         #logverb('  Tstep ', tstep)
         # print('Stepped alpha=', alpha, 'for dlogprob', dlogprob)
+        #print ("LTimesz", lt)
         if variance:
             return dlogprob, X, alpha, var
         return dlogprob, X, alpha
 
     def optimize_loop(self, tractor, dchisq=0., steps=50, check_step=None, **kwargs):
         R = {}
-        #print ("LSQR OPTIMIZE")
+        print ("LSQR OPTIMIZE")
         #print (self.optimize)
         t = time.time()
         for step in range(steps):
@@ -344,12 +353,13 @@ class LsqrOptimizer(Optimizer):
                 r = check_step(optimizer=self, tractor=tractor, dlnp=dlnp, X=X, alpha=alpha)
                 if not r:
                     break
-            # print('Opt step: dlnp', dlnp,
-            #      ', '.join([str(src) for src in tractor.getCatalog()]))
+            print('Opt step: dlnp', dlnp,
+                  ', '.join([str(src) for src in tractor.getCatalog()]))
             if dlnp <= dchisq:
                 break
         lt[2] += time.time()-t
         R.update(steps=step)
+        #print ("LTimesx:",lt)
         return R
 
     def getUpdateDirection(self, tractor, allderivs, damp=0., priors=True,

--- a/tractor/miscutils.py
+++ b/tractor/miscutils.py
@@ -9,6 +9,43 @@ import gc
 # Late-load kernel to avoid CuPy dependency on CPU
 _mog_eval_kernel = None
 
+# In tractor/miscutils.py
+_splat_kernel = None
+
+def get_splat_kernel():
+    global _splat_kernel
+    if _splat_kernel is None:
+        _splat_kernel = cp.RawKernel(r'''
+        extern "C" __global__
+        void splat_patch(const float* patches, float* images,
+                        const int* x0, const int* y0, const float* counts,
+                        int Hp, int Wp, int Hi, int Wi) {
+            // blockIdx.z is the image index in the batch
+            int z = blockIdx.z;
+            // px, py are coordinates within the patch
+            int py = blockIdx.y * blockDim.y + threadIdx.y;
+            int px = blockIdx.x * blockDim.x + threadIdx.x;
+
+            if (py < Hp && px < Wp) {
+                int iy = y0[z] + py;
+                int ix = x0[z] + px;
+
+                // Safety check: Ensure we don't write outside the image bounds
+                if (iy >= 0 && iy < Hi && ix >= 0 && ix < Wi) {
+                    // patches shape: (Z, Hp, Wp)
+                    // images shape: (Z, Hi, Wi)
+                    int img_idx = z * (Hi * Wi) + iy * Wi + ix;
+                    int pat_idx = z * (Hp * Wp) + py * Wp + px;
+
+                    // atomicAdd is required for when we batch multiple sources
+                    // that might overlap on the same pixel.
+                    atomicAdd(&images[img_idx], patches[pat_idx] * counts[z]);
+                }
+            }
+        }
+        ''', 'splat_patch')
+    return _splat_kernel
+
 def get_mog_eval_kernel():
     global _mog_eval_kernel
     if _mog_eval_kernel is None:
@@ -111,18 +148,36 @@ def batch_correlate1d_cpu(a, b, axis=1, mode='constant'):
         nclip = r-n 
     if npad > 0:
         if npad % 2 == 0:
-            padded_b = np.pad(b, [0, npad//2])
+            #padded_b = cp.pad(b, [0, npad//2])
+            # BUG FIX: Specify (0,0) for the first axis to avoid padding the batch
+            padded_b = np.pad(b, [(0, 0), (0, npad // 2)])
         else:
             padded_b = np.pad(b, [(0,0), (npad//2+1, npad//2)])
     else:
         padded_b = b
-    f_a = np.fft.fft(a, r, axis=axis)
-    f_b = np.fft.fft(padded_b, r, axis=1)
+
+    # USE RFFT: This keeps the frequency domain half-sized (~3.25 GB instead of 6.5 GB)
+    f_a = np.fft.rfft(a, r, axis=axis)
+    f_b = np.fft.rfft(padded_b, r, axis=1)
+    print (f'{f_a.shape=} {f_b.shape=} {a.shape=} {b.shape=}')
+    print (f'{np.conj(f_b).shape=}')
+    del padded_b
+
+    # Correlation is f_a * conj(f_b)
+    # rfft output is Hermitian symmetric, so conj() works fine here
     if axis == 1:
         f_p = np.einsum("ijk,ij->ijk", f_a, np.conj(f_b))
     else:
         f_p = np.einsum("ijk,ik->ijk", f_a, np.conj(f_b))
-    c = np.real(np.fft.fftshift(np.fft.ifft(f_p, axis=axis), axes=(axis)))
+    del f_a, f_b
+
+    # irfft automatically knows the output is real and handles the symmetry
+    # Use the 'n' parameter to ensure the output length matches 'r'
+    c = np.fft.irfft(f_p, n=r, axis=axis)
+    del f_p
+    # Shift and Clip
+    c = np.fft.fftshift(c, axes=(axis))
+
     if mode == 'full':
         return c
     if axis == 1:
@@ -147,7 +202,9 @@ def batch_correlate1d_gpu(a, b, axis=1, mode='constant'):
         nclip = r-n
     if npad > 0:
         if npad % 2 == 0:
-            padded_b = cp.pad(b, [0, npad//2])
+            #padded_b = cp.pad(b, [0, npad//2])
+            # BUG FIX: Specify (0,0) for the first axis to avoid padding the batch
+            padded_b = cp.pad(b, [(0, 0), (0, npad // 2)])
         else:
             padded_b = cp.pad(b, [(0,0), (npad//2+1, npad//2)])
     else:
@@ -203,3 +260,77 @@ def batch_correlate1d_gpu(a, b, axis=1, mode='constant'):
     if axis == 1:
         return c[:,nclip//2:-nclip//2,:]
     return c[:,:,nclip//2:-nclip//2]
+
+def batch_correlate1d_cpu_fast(a, b, axis=1, mode='constant'):
+    import numpy as np
+    # a: (batch, height, width)
+    # b: (batch, filter_len)
+    z, m, n = a.shape
+    y, x = b.shape
+
+    # Calculate linear correlation length
+    r = (m + x - 1) if axis == 1 else (n + x - 1)
+
+    # 1. Align the Filter: Place the center of the filter at index 0
+    # This ensures no translation is introduced during correlation.
+    center = x // 2
+    b_padded = np.zeros((z, r), dtype=a.dtype)
+    b_padded[:, :x] = b
+    b_padded = np.roll(b_padded, -center, axis=1)
+
+    # 2. FFT Correlation (Frequency domain multiplication)
+    f_a = np.fft.rfft(a, n=r, axis=axis)
+    f_b = np.fft.rfft(b_padded, n=r, axis=1)
+
+    # Correlation = F(a) * conj(F(b))
+    if axis == 1:
+        f_p = f_a * np.conj(f_b[:, :, np.newaxis])
+    else:
+        f_p = f_a * np.conj(f_b[:, np.newaxis, :])
+
+    # 3. Inverse FFT
+    c = np.fft.irfft(f_p, n=r, axis=axis)
+
+    # 4. Slicing: The first m (or n) elements now correspond exactly
+    # to the centered correlation indices of the input image.
+    if axis == 1:
+        return c[:, :m, :]
+    else:
+        return c[:, :, :n]
+
+def batch_correlate1d_gpu_fast(a, b, axis=1, mode='constant'):
+    import cupy as cp
+    # a: (batch, height, width)
+    # b: (batch, filter_len)
+    z, m, n = a.shape
+    y, x = b.shape
+
+    # Calculate linear correlation length
+    r = (m + x - 1) if axis == 1 else (n + x - 1)
+
+    # 1. Align the Filter: Place the center of the filter at index 0
+    # This ensures no translation is introduced during correlation.
+    center = x // 2
+    b_padded = cp.zeros((z, r), dtype=a.dtype)
+    b_padded[:, :x] = b
+    b_padded = cp.roll(b_padded, -center, axis=1)
+
+    # 2. FFT Correlation (Frequency domain multiplication)
+    f_a = cp.fft.rfft(a, n=r, axis=axis)
+    f_b = cp.fft.rfft(b_padded, n=r, axis=1)
+
+    # Correlation = F(a) * conj(F(b))
+    if axis == 1:
+        f_p = f_a * cp.conj(f_b[:, :, cp.newaxis])
+    else:
+        f_p = f_a * cp.conj(f_b[:, np.newaxis, :])
+
+    # 3. Inverse FFT
+    c = cp.fft.irfft(f_p, n=r, axis=axis)
+
+    # 4. Slicing: The first m (or n) elements now correspond exactly
+    # to the centered correlation indices of the input image.
+    if axis == 1:
+        return c[:, :m, :]
+    else:
+        return c[:, :, :n]

--- a/tractor/pointsource.py
+++ b/tractor/pointsource.py
@@ -37,6 +37,7 @@ class SingleProfileSource(BasicSource):
     def getModelPatch(self, img, minsb=None, modelMask=None, **kwargs):
         ct1[0] += 1
         #print ("CT1:", ct1)
+        #print ("getModelPatch1")
         counts = img.getPhotoCal().brightnessToCounts(self.brightness)
         if counts == 0:
             return None
@@ -104,9 +105,11 @@ class PointSource(MultiParams, SingleProfileSource):
 
     def getUnitFluxModelPatch(self, img, minval=0., derivs=False,
                               modelMask=None, **kwargs):
+        #print ("getUnitFluxModelPatch1")
         ct1[1] += 1
         #print ("CT1:", ct1)
         (px, py) = img.getWcs().positionToPixel(self.getPosition(), self)
+        #print (f'CPU {px=} {py=} {img=} {self.getPosition()=}', self)
         H, W = img.shape
         psf = self._getPsf(img)
         # quit early if the requested position is way outside the image bounds

--- a/tractor/psf.py
+++ b/tractor/psf.py
@@ -16,6 +16,12 @@ from tractor.utils import BaseParams, ParamList, MultiParams, MogParams
 from tractor import mixture_profiles as mp
 from tractor import ducks
 from tractor.utils import savetxt_cpu_append
+import time
+
+tcps = np.zeros(6)
+
+def print_tcps():
+    print (f'{tcps=}')
 
 if sys.version_info[0] == 2:
     # Py2
@@ -55,6 +61,7 @@ def lanczos_shift_image(img, dx, dy, inplace=False, force_python=False):
     # yuck!  (don't change this without ensuring the "restrict"
     # keyword still applies in lanczos_shift_3f!)
     if inplace:
+        #print ("INPLACE")
         img[:,:] = outimg
     return outimg
 
@@ -154,6 +161,7 @@ class PixelizedPSF(BaseParams, ducks.ImageCalibration):
         '''
         # ensure float32 and align
         img = img.astype(np.float32)
+        #print ("INIT PSF", img.shape, img.max(), img.sum(), sampling)
         self.img = np.require(img, requirements=['A'])
         H,W = img.shape
         assert((H % 2) == 1)
@@ -208,8 +216,10 @@ class PixelizedPSF(BaseParams, ducks.ImageCalibration):
 
         from astrometry.util.miscutils import get_overlapping_region
 
+        t = time.time()
         # get PSF image at desired pixel location
         img = self.getImage(px, py)
+        #print ("PSF1A", img.shape, img.max(), img.sum())
         #print (f'{px=} {py=} {radius=} {minval=}')
 
         if radius is not None:
@@ -221,7 +231,7 @@ class PixelizedPSF(BaseParams, ducks.ImageCalibration):
                       max(cx-R, 0) : min(cx+R+1,W-1)]
             
         H, W = img.shape
-        #print (f'{H=} {W=}')
+        #print (f'CPU {H=} {W=}')
         # float() required because builtin round(np.float64(11.0)) returns 11.0 !!
         ix = round(float(px))
         iy = round(float(py))
@@ -229,11 +239,14 @@ class PixelizedPSF(BaseParams, ducks.ImageCalibration):
         dy = py - iy
         x0 = ix - W // 2
         y0 = iy - H // 2
-        #print (f'{ix=} {iy=} {dx=} {dy=} {x0=} {y0=}')
+        #print (f'CPU {ix=} {iy=} {dx=} {dy=} {x0=} {y0=}')
 
         if modelMask is None:
             #print ("NO MM")
-            outimg = lanczos_shift_image(img, dx, dy)
+            t1 = time.time()
+            #outimg = lanczos_shift_image(img, dx, dy)
+            outimg = img
+            tcps[0] += time.time()-t1
             return Patch(x0, y0, outimg)
 
         mh, mw = modelMask.shape
@@ -257,13 +270,20 @@ class PixelizedPSF(BaseParams, ducks.ImageCalibration):
         padding = L
         # Create a modelMask + padding sized stamp and insert PSF image into it
         mm = np.zeros((mh+2*padding, mw+2*padding), np.float32)
+        #print (f'{mm.shape=} {img.shape=}')
         #print ("OVERLAPY", my0-y0-padding,my0-y0+mh-1+padding, 0, H-1)
         yi,yo = get_overlapping_region(my0-y0-padding, my0-y0+mh-1+padding, 0, H-1)
         #print ("YI", yi, "YO", yo)
         xi,xo = get_overlapping_region(mx0-x0-padding, mx0-x0+mw-1+padding, 0, W-1)
         mm[yo,xo] = img[yi,xi]
+        tcps[1] += time.time()-t
+        #print ("PSF IMAGE", img.max(), img.shape, np.where(img == img.max()))
+        #print (f'{mx0=} {my0=} {yo=} {xo=} {yi=} {xi=}')
+        #print (f'{x0=} {padding=} {mw=} {W=}')
         #print (mm[yo,xo].shape, img[yi,xi].shape)
+        t = time.time()
         mm = lanczos_shift_image(mm, dx, dy)
+        tcps[0] += time.time()-t
         mm = mm[padding:-padding, padding:-padding]
         assert(np.all(np.isfinite(mm)))
 
@@ -526,6 +546,7 @@ class GaussianMixturePSF(MogParams, ducks.ImageCalibration):
         # clipExtent: [xl,xh, yl,yh] to avoid rendering a model that extends
         # outside the image bounds.
         #
+        #print ("getPointSourcePatch2", self)
         if modelMask is not None:
             if modelMask.mask is None:
                 return self.mog.evaluate_grid(modelMask.x0, modelMask.x1,
@@ -961,6 +982,7 @@ class NCircularGaussianPSF(MultiParams, ducks.ImageCalibration):
     # returns a Patch object.
     def getPointSourcePatch(self, px, py, minval=0., radius=None,
                             modelMask=None, clipExtent=None, **kwargs):
+        #print ("getPointSourcePatch3", self)
         if modelMask is not None:
             x0, x1, y0, y1 = modelMask.extent
         else:

--- a/tractor/smarter_dense_optimizer.py
+++ b/tractor/smarter_dense_optimizer.py
@@ -1,9 +1,10 @@
+from tractor import ProfileGalaxy, HybridPSF, PointSource
 from tractor.constrained_optimizer import ConstrainedOptimizer
 import numpy as np
 from numpy.linalg import lstsq, LinAlgError
 from tractor.utils import savetxt_cpu_append
 import time
-ts = np.zeros(2)
+ts = np.zeros(7)
 
 class SmarterDenseOptimizer(ConstrainedOptimizer):
 
@@ -49,6 +50,7 @@ class SmarterDenseOptimizer(ConstrainedOptimizer):
                 # this is vij * bij. It goes in the `col` element of the vector.
                 ATB_prior[col] += vij * bij
 
+        #print (f'{ATA_prior=} {ATB_prior=}')
         return ATA_prior, ATB_prior
 
 
@@ -158,6 +160,8 @@ class SmarterDenseOptimizer(ConstrainedOptimizer):
         img_offsets = {}
         Npixels = 0
         for iparam,derivs in enumerate(allderivs):
+            if len(derivs) == 0:
+                continue
             for deriv, img in derivs:
                 if img in img_offsets:
                     continue
@@ -167,6 +171,9 @@ class SmarterDenseOptimizer(ConstrainedOptimizer):
                 # to avoid overflow!
                 Npixels += (int(x1)-int(x0)) * (int(y1)-int(y0))
 
+        if isinstance(tractor.catalog[0], PointSource):
+            ts[0] += time.time()-t
+        t = time.time()
         Npriors = 0
         if priors:
             ''' getLogPriorDerivatives()
@@ -208,6 +215,7 @@ class SmarterDenseOptimizer(ConstrainedOptimizer):
                 Ncols = len(live_params)
                 #print('new Ncols:', Ncols)
 
+        t = time.time()
         #print('DenseOptimizer.getUpdateDirection : N params (cols) %i, N pix %i, N priors %i' %
         #      (Ncols, Npixels, Npriors))
 
@@ -236,6 +244,7 @@ class SmarterDenseOptimizer(ConstrainedOptimizer):
                 if deriv.patch is None:
                     continue
                 inverrs = img.getInvError()
+                #print ("INVERR", inverrs.sum())
 
                 dx0,dx1,dy0,dy1 = deriv.extent
                 x0,x1,y0,y1 = img_bounds[img]
@@ -334,6 +343,9 @@ class SmarterDenseOptimizer(ConstrainedOptimizer):
             if scale_columns:
                 colscales2[col] = scale2
 
+        if isinstance(tractor.catalog[0], PointSource):
+            ts[2] += time.time()-t
+        t = time.time()
         if Npriors > 0:
             rA, cA, vA, pb, mub = priorVals
             #print('Priors: pb', pb, 'mub', mub)
@@ -374,6 +386,17 @@ class SmarterDenseOptimizer(ConstrainedOptimizer):
             h = y1-y0
             B[rowstart: rowstart + w*h] = chi.flat
             del chi
+        #print ("A", A.shape, "B", B.shape, "colscales2", colscales2.shape)
+        #np.savetxt("ca1.txt", A)
+        #np.savetxt("cb1.txt", B)
+        #np.savetxt("cs2.txt", colscales2)
+        # Check flux and which params are actually being optimized
+        #print(f"DEBUG CPU: Flux = {tractor.catalog[0].getBrightness()}")
+        #print(f"DEBUG CPU: Thawed Params = {tractor.getThawedParams()}")
+        #print(f"DEBUG CPU: Param Names = {tractor.getParamNames()}")
+        if isinstance(tractor.catalog[0], PointSource):
+            ts[3] += time.time()-t
+        t = time.time()
 
         try:
             X,_,_,_ = lstsq(A, B, rcond=None)
@@ -388,6 +411,9 @@ class SmarterDenseOptimizer(ConstrainedOptimizer):
             print('B finite:', Counter(np.isfinite(B.ravel())))
             return None
         #print ("OUTPUT SHAPES CPU1 ", A.shape, B.shape, X.shape)
+        if isinstance(tractor.catalog[0], PointSource):
+            ts[4] += time.time()-t
+        t = time.time()
 
         if A is not None:
             Aorig = A.copy()
@@ -421,9 +447,9 @@ class SmarterDenseOptimizer(ConstrainedOptimizer):
             #print ("C", c, "I", i, X[i])
             X_full[c] = X[i]
         X = X_full
-        #print('-> SMARTER X', X)
-        ts[0] += time.time()-t
-        #print(f'{ts=}')
+        print('-> SMARTER X', X, X.shape)
+        #import sys
+        #sys.exit(-1)
 
         if get_A_matrix:
             if scale_columns:
@@ -441,7 +467,14 @@ class SmarterDenseOptimizer(ConstrainedOptimizer):
             for c,i in column_map.items():
                 A_full[:,c] = A[:,i]
             A = A_full
+            #print (f'{A=} ', A.shape)
+            if isinstance(tractor.catalog[0], PointSource):
+                ts[5] += time.time()-t
+                print(f'{ts=}')
 
             return X,A,colscales,B,Aorig
 
+        if isinstance(tractor.catalog[0], PointSource):
+            ts[5] += time.time()-t
+            print(f'{ts=}')
         return X


### PR DESCRIPTION
Merge "craig clean" in to craig_factored_merge

craig_clean has two steps of differences from craig_factored_merge: 1) It includes new GPU logic or point source fitting, tryUpdates, and GPULsqrOptimizer.  2) It cleans up unused branches and options and print and timing statements.

Logs from craig_clean updates:
    Commit with full debug info for refactor to GPU-ize point source
    fitting, tryUpdates, and improve GPULsqrOptimizer for background
    fitting.  Commit message generated by AI below:
    
    Subject: Optimize GPU fitting pipelines and improve memory/edge-case robustness
    Description:
    
    This commit implements a series of significant performance optimizations and stability fixes for the GPU-accelerated fitting pipelines, focusing on tryUpdates, GPULsqrOptimizer, and handling of complex image stacks.
    
    Key Changes:
    
        GPU Point Source Fitter & Batching:
    
            Implemented a hybrid strategy for getSingleImageUpdateDirection where CPU-based model images (including Lanczos shifting) are batched into 3D arrays before GPU processing.
    
    Achieved a 2x speedup in update direction computation while maintaining full numerical correctness.
    
    Optimized getBatchModelImages to handle cases where allderivs and tractor.images counts differ.
    
    GPU tryUpdates for Point Sources & Galaxies:
    
        Migrated galaxy tryUpdates to the GPU, achieving a 3x speedup compared to the CPU version.
    
    Transitioned to float64 precision for point source tryUpdates to eliminate occasional divergence from CPU results.
    
    Eliminated redundant CPU getLogProb() calls by performing batch calculations entirely on the GPU, yielding an additional 33% speedup.
    
    Memory-Efficient ("Less Mem") GPU Mode:
    
        Introduced a new memory-prediction helper to check available VRAM before execution.
    
    Implemented a sequential image-looping fallback within the GPU kernels for large blobs that exceed memory limits, preventing crashes while retaining GPU acceleration.
    
    GPULsqrOptimizer Enhancements:
    
        Refactored background and sky fitting to use the new batching logic developed for tryUpdates.
    
    Optimized sparse matrix accumulation, making the process 4x faster.
    
    Overall algorithm runtime reduced from 292s to 99s (excluding solver time).
    
    Handling None modelMasks & Edge Cases:
    
        Added logic to filter out images where modelMask is None (e.g., objects off the edge of a segment).
    
    The tractor context is now dynamically updated to only include valid images before proceeding with GPU fitting.
    
    Ensured full CPU fallback if all modelMasks in a stack are None.
    
    Performance Impact:
    
        Total fitblobs runtime for large test blobs (e.g., Blob 1 of 0001p000) reduced from 5842s (CPU) to 1975s (GPU).
    
    Bricks with long runtimes see improvements of up to 2x faster compared to previous GPU versions.


     Optimize GPU memory usage and improve robustness in engine and optimizer
    
     This commit introduces a memory-efficient GPU processing mode and improves
     the reliability of the GPU-accelerated fitting paths.
    
     tractor/engine.py:
     - Add 'use_less_mem' and 'ie_stack' support to log-likelihood batch methods.
     - Implement sequential image processing in getLogLikelihoodBatch to minimize
       VRAM footprint for large FFT workspaces.
     - Add manual memory management (CuPy block clearing) during batch operations.
    
     tractor/factored_optimizer.py:
     - Filter out non-overlapping images (None masks) before GPU tryUpdates.
     - Implement 'use_less_mem' logic in GPUFriendlyOptimizer to handle large
       image stacks by iterating through valid images when VRAM is low.
     - Add robust state restoration (images/masks) using try...finally blocks.
     - Improve error reporting with tracebacks and fallback to CPU on GPU failure.
     - Add debug logging for linear algebra internals and improve NaN handling.
